### PR TITLE
Changes for serving executors in Sparkla

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/package.json
+!/src/
+!/tsconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12
+
+WORKDIR /usr/bin/executa
+
+COPY package.json .
+RUN npm install
+
+COPY . .
+RUN npm run build:node
+
+CMD node dist/lib/cli serve --stdio

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ cover:
 build:
 	npm run build
 
+docker:
+	docker build --tag stencila/executa .
+
 docs:
 	npm run docs
 .PHONY: docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencila/executa",
-  "version": "0.2.0",
+  "version": "0.2.0-next.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2458,8 +2458,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2609,7 +2608,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3378,8 +3376,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -5358,8 +5355,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -6034,7 +6030,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6626,7 +6621,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -9040,7 +9034,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -13187,8 +13180,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencila/executa",
-  "version": "0.2.0",
+  "version": "0.2.0-next.1",
   "description": "Execution delegator for various language backends.",
   "main": "./dist/lib/index.js",
   "browser": "./dist/browser/index.js",
@@ -16,7 +16,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cover": "jest --coverage",
-    "build": "tsc && rollup --config",
+    "build": "npm run build:node && npm run build:browser",
+    "build:node": "tsc",
+    "build:browser": "rollup --config",
     "docs": "npm run docs:readme && npm run docs:ts",
     "docs:readme": "markdown-toc -i --maxdepth=4 README.md",
     "docs:ts": "typedoc --options typedoc.js ./src"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Execution delegator for various language backends.",
   "main": "./dist/lib/index.js",
   "browser": "./dist/browser/index.js",
-  "es2015": "./dist/esm/index.js",
   "files": [
     "dist"
   ],
@@ -17,7 +16,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cover": "jest --coverage",
-    "build": "rollup --config",
+    "build": "tsc && rollup --config",
     "docs": "npm run docs:readme && npm run docs:ts",
     "docs:readme": "markdown-toc -i --maxdepth=4 README.md",
     "docs:ts": "typedoc --options typedoc.js ./src"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencila/executa",
-  "version": "0.2.0-next.1",
+  "version": "0.2.0-next.2",
   "description": "Execution delegator for various language backends.",
   "main": "./dist/lib/index.js",
   "browser": "./dist/browser/index.js",
@@ -57,6 +57,7 @@
     "fastify-cors": "^2.1.3",
     "fastify-jwt": "^1.1.0",
     "fastify-websocket": "^0.6.0",
+    "glob": "^7.1.4",
     "isomorphic-ws": "^4.0.1",
     "length-prefixed-stream": "^2.0.0",
     "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "./dist/lib/index.js",
   "browser": "./dist/browser/index.js",
   "es2015": "./dist/esm/index.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "cli": "ts-node src/cli.ts",
     "cli:dev": "ts-node-dev src/cli.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,18 +9,23 @@ export default [
   {
     input: 'src/index.browser.ts',
 
-    plugins: [typescript({
-      tsconfig: 'tsconfig.browser.json'
-    }),
-    commonjs({
-      extensions: ['.js', '.ts'],
-      namedExports: {
-        '@stencila/schema': ['nodeType', 'isPrimitive']
-      }
-    }),
-    json(), babel({
-      exclude: 'node_modules/**'
-    }), builtins(), resolve()],
+    plugins: [
+      typescript({
+        tsconfig: 'tsconfig.browser.json'
+      }),
+      commonjs({
+        extensions: ['.js', '.ts'],
+        namedExports: {
+          '@stencila/schema': ['nodeType', 'isPrimitive']
+        }
+      }),
+      json(),
+      babel({
+        exclude: 'node_modules/**'
+      }),
+      builtins(),
+      resolve()
+    ],
 
     // Do not bundle modules that provide things already
     // in the browser. Put them in `output.globals`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,41 +5,22 @@ import json from 'rollup-plugin-json'
 import resolve from 'rollup-plugin-node-resolve'
 import typescript from 'rollup-plugin-typescript2'
 
-const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.browser.json'
-  }),
-  commonjs({
-    extensions: ['.js', '.ts'],
-    namedExports: {
-      '@stencila/schema': ['nodeType', 'isPrimitive']
-    }
-  }),
-  json(),
-  babel({
-    exclude: 'node_modules/**'
-  })
-]
-
 export default [
-  {
-    input: 'src/index.ts',
-    plugins,
-    output: [
-      {
-        dir: 'dist/lib',
-        format: 'cjs'
-      },
-      {
-        dir: 'dist/esm',
-        format: 'esm'
-      }
-    ]
-  },
   {
     input: 'src/index.browser.ts',
 
-    plugins: [...plugins, builtins(), resolve()],
+    plugins: [typescript({
+      tsconfig: 'tsconfig.browser.json'
+    }),
+    commonjs({
+      extensions: ['.js', '.ts'],
+      namedExports: {
+        '@stencila/schema': ['nodeType', 'isPrimitive']
+      }
+    }),
+    json(), babel({
+      exclude: 'node_modules/**'
+    }), builtins(), resolve()],
 
     // Do not bundle modules that provide things already
     // in the browser. Put them in `output.globals`

--- a/src/base/Client.ts
+++ b/src/base/Client.ts
@@ -122,5 +122,5 @@ export default abstract class Client implements Interface {
 }
 
 export interface ClientType {
-  new (address: Address): Client
+  new (address: any): Client
 }

--- a/src/base/Client.ts
+++ b/src/base/Client.ts
@@ -60,6 +60,20 @@ export default abstract class Client implements Interface {
   }
 
   /**
+   * Call the remote `Executor`'s `begin` method
+   */
+  public async begin(node: Node): Promise<Node> {
+    return this.call<Node>(Method.begin, { node })
+  }
+
+  /**
+   * Call the remote `Executor`'s `end` method
+   */
+  public async end(node: Node): Promise<Node> {
+    return this.call<Node>(Method.end, { node })
+  }
+
+  /**
    * Call a method of a remote `Executor`.
    *
    * @param method The name of the method

--- a/src/base/Executor.test.ts
+++ b/src/base/Executor.test.ts
@@ -380,7 +380,12 @@ describe('Executor', () => {
    */
   test('peers: direct', async () => {
     const deepThought = new DeepThought()
+    const deepThoughtServer = new DirectServer()
+    await deepThoughtServer.start(deepThought)
+
     const calculator = new Calculator()
+    const calculatorServer = new DirectServer()
+    await calculatorServer.start(calculator)
 
     const executor = new Executor(
       [
@@ -389,7 +394,7 @@ describe('Executor', () => {
             addresses: {
               direct: {
                 type: Transport.direct,
-                server: new DirectServer(deepThought)
+                server: deepThoughtServer
               }
             },
             capabilities: await deepThought.capabilities()
@@ -398,7 +403,7 @@ describe('Executor', () => {
             addresses: {
               direct: {
                 type: Transport.direct,
-                server: new DirectServer(calculator)
+                server: calculatorServer
               }
             },
             capabilities: await calculator.capabilities()

--- a/src/base/Executor.ts
+++ b/src/base/Executor.ts
@@ -18,7 +18,9 @@ export enum Method {
   encode = 'encode',
   compile = 'compile',
   build = 'build',
-  execute = 'execute'
+  execute = 'execute',
+  begin = 'begin',
+  end = 'end'
 }
 
 /**
@@ -124,6 +126,22 @@ export abstract class Interface {
    * @returns The executed node
    */
   abstract async execute(node: Node): Promise<Node>
+
+  /**
+   * Begin running a `Node`.
+   *
+   * @param node The node to run
+   * @returns The node after it has begun running
+   */
+  abstract async begin(node: Node): Promise<Node>
+
+  /**
+   * End running a `Node`.
+   *
+   * @param node The running node
+   * @returns The node after it has ended running
+   */
+  abstract async end(node: Node): Promise<Node>
 
   /**
    * Call one of the above methods.
@@ -463,7 +481,8 @@ export class Executor implements Interface {
    * Execute a `Node`.
    *
    * Walks the node tree and attempts to delegate
-   * execution of certain types of nodes (currently `CodeChunk` and `CodeExpression`).
+   * execution of certain types of nodes
+   * (currently `CodeChunk` and `CodeExpression`).
    *
    * @param node The node to execute
    */
@@ -487,6 +506,20 @@ export class Executor implements Interface {
       }
       return Promise.resolve(node)
     })
+  }
+
+  /**
+   * Begin running a `Node`.
+   */
+  public begin(node: Node): Promise<Node> {
+    return this.delegate(Method.begin, { node }, () => Promise.resolve(node))
+  }
+
+  /**
+   * End running a `Node`.
+   */
+  public end(node: Node): Promise<Node> {
+    return this.delegate(Method.end, { node }, () => Promise.resolve(node))
   }
 
   public async call(

--- a/src/base/InternalError.ts
+++ b/src/base/InternalError.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal error
+ *
+ * This custom error class simply serves to identify
+ * errors that should only occur due to problems with
+ * internal code (e.g. not overriding a base method properly) or
+ * configuration (e.g. not setting an environment variable).
+ *
+ * Messages should be written for developers using this library,
+ * not for end users.
+ *
+ * @see JsonRpcError
+ */
+export class InternalError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InternalError'
+  }
+}

--- a/src/base/JsonRpcError.ts
+++ b/src/base/JsonRpcError.ts
@@ -3,12 +3,46 @@
  *
  * @see {@link https://www.jsonrpc.org/specification#error_object}
  */
+
+/**
+ * Error codes defined in JSON-RPC 2.0
+ *
+ * Codes -32000 to -32099	are reserved for implementation-defined server-errors.
+ */
+export enum JsonRpcErrorCode {
+  /**
+   * Invalid JSON was received by the server.
+   * An error occurred on the server while parsing the JSON text.
+   */
+  ParseError = -32700,
+  /**
+   * The JSON sent is not a valid Request object.
+   */
+  InvalidRequest = -32600,
+  /**
+   * The method does not exist / is not available.
+   */
+  MethodNotFound = -32601,
+  /**
+   * Invalid method parameter(s).
+   */
+  InvalidParams = -32602,
+  /**
+   * Internal JSON-RPC error.
+   */
+  InternalError = -32603,
+  /**
+   * Implementation defined server error.
+   */
+  ServerError = -32000
+}
+
 export default class JsonRpcError {
   /**
    * A Number that indicates the error type that occurred.
    * This MUST be an integer.
    */
-  public readonly code: number
+  public readonly code: JsonRpcErrorCode
 
   /**
    * A String providing a short description of the error.

--- a/src/base/Server.ts
+++ b/src/base/Server.ts
@@ -107,13 +107,13 @@ export default abstract class Server {
           )
           break
         case 'compile':
-          result = await this.executor.compile(param(request, 0, 'node'))
-          break
         case 'build':
-          result = await this.executor.build(param(request, 0, 'node'))
-          break
         case 'execute':
-          result = await this.executor.execute(param(request, 0, 'node'))
+        case 'begin':
+        case 'end':
+          result = await this.executor[request.method](
+            param(request, 0, 'node')
+          )
           break
         default:
           throw new JsonRpcError(

--- a/src/base/Server.ts
+++ b/src/base/Server.ts
@@ -1,8 +1,9 @@
 import { Executor } from './Executor'
-import Error from './JsonRpcError'
+import JsonRpcError, { JsonRpcErrorCode } from './JsonRpcError'
 import JsonRpcRequest from './JsonRpcRequest'
 import JsonRpcResponse from './JsonRpcResponse'
 import { Address } from './Transports'
+import { InternalError } from './InternalError'
 
 /**
  * A base server class that passes JSON-RPC requests
@@ -12,12 +13,7 @@ export default abstract class Server {
   /**
    * The executor that this server dispatches to.
    */
-  private executor: Executor
-
-  public constructor(executor?: Executor) {
-    if (executor === undefined) executor = new Executor()
-    this.executor = executor
-  }
+  protected executor?: Executor
 
   /**
    * Get the address of the server
@@ -35,6 +31,9 @@ export default abstract class Server {
     request: string | JsonRpcRequest,
     stringify = true
   ): Promise<string | JsonRpcResponse> {
+    if (this.executor === undefined)
+      throw new InternalError('Executor has not been initialized')
+
     let id = -1
     let result
     let error
@@ -47,18 +46,27 @@ export default abstract class Server {
       required = true
     ): any {
       if (request.params === undefined)
-        throw new Error(-32600, 'Invalid request: missing "params" property')
+        throw new JsonRpcError(
+          JsonRpcErrorCode.InvalidRequest,
+          'Invalid request: missing "params" property'
+        )
       const value = Array.isArray(request.params)
         ? request.params[index]
         : request.params[name]
       if (required && value === undefined)
-        throw new Error(-32602, `Invalid params: "${name}" is missing`)
+        throw new JsonRpcError(
+          JsonRpcErrorCode.InvalidParams,
+          `Invalid params: "${name}" is missing`
+        )
       return value
     }
 
     try {
       if (request === null) {
-        throw new Error(-32600, `Invalid request`)
+        throw new JsonRpcError(
+          JsonRpcErrorCode.InvalidRequest,
+          `Invalid request`
+        )
       }
 
       if (typeof request === 'string') {
@@ -66,7 +74,10 @@ export default abstract class Server {
         try {
           request = JSON.parse(request) as JsonRpcRequest
         } catch (err) {
-          throw new Error(-32700, `Parse error: ${err.message}`)
+          throw new JsonRpcError(
+            JsonRpcErrorCode.ParseError,
+            `Parse error: ${err.message}`
+          )
         }
       }
 
@@ -74,7 +85,10 @@ export default abstract class Server {
       id = request.id
 
       if (request.method === undefined)
-        throw new Error(-32600, 'Invalid request: missing "method" property')
+        throw new JsonRpcError(
+          JsonRpcErrorCode.MethodNotFound,
+          'Invalid request: missing "method" property'
+        )
 
       switch (request.method) {
         case 'manifest':
@@ -102,15 +116,22 @@ export default abstract class Server {
           result = await this.executor.execute(param(request, 0, 'node'))
           break
         default:
-          throw new Error(-32601, `Method not found: "${request.method}"`)
+          throw new JsonRpcError(
+            JsonRpcErrorCode.MethodNotFound,
+            `Method not found: "${request.method}"`
+          )
       }
     } catch (exc) {
       error =
-        exc instanceof Error
+        exc instanceof JsonRpcError
           ? exc
-          : new Error(-32603, `Internal error: ${exc.message}`, {
-              trace: exc.stack
-            })
+          : new JsonRpcError(
+              JsonRpcErrorCode.ServerError,
+              `Internal error: ${exc.message}`,
+              {
+                trace: exc.stack
+              }
+            )
     }
 
     const response = new JsonRpcResponse(id, result, error)
@@ -120,9 +141,12 @@ export default abstract class Server {
   /**
    * Start the server
    *
-   * Derived classes may override this method.
+   * When overriding this method, derived classes should
+   * call this method, or ensure that `executor` is set themselves.
    */
-  public async start(): Promise<void> {
+  public start(executor?: Executor): Promise<void> {
+    if (executor === undefined) executor = new Executor()
+    this.executor = executor
     return Promise.resolve()
   }
 
@@ -131,14 +155,14 @@ export default abstract class Server {
    *
    * Derived classes may override this method.
    */
-  public async stop(): Promise<void> {
+  public stop(): Promise<void> {
     return Promise.resolve()
   }
 
   /**
    * Run the server with graceful shutdown on `SIGINT` or `SIGTERM`
    */
-  public async run(): Promise<void> {
+  public run(): Promise<void> {
     const stop = (): void => {
       this.stop()
         .then(() => process.exit())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,9 +13,14 @@ import StdioClient from './stdio/StdioClient'
 import HttpServer from './http/HttpServer'
 import TcpServer from './tcp/TcpServer'
 import WebSocketServer from './ws/WebSocketServer'
-import { HttpAddress, TcpAddress, WebSocketAddress, VsockAddress } from './base/Transports'
-import VsockServer from './vsock/VsockServer';
-import StdioServer from './stdio/StdioServer';
+import {
+  HttpAddress,
+  TcpAddress,
+  WebSocketAddress,
+  VsockAddress
+} from './base/Transports'
+import VsockServer from './vsock/VsockServer'
+import StdioServer from './stdio/StdioServer'
 
 const { _: args, ...options } = minimist(process.argv.slice(2))
 
@@ -35,24 +40,40 @@ const main = async () => {
     servers.push(new StdioServer())
   }
   if (options.vsock !== undefined) {
-    servers.push(new VsockServer(new VsockAddress(
-      typeof options.vsock === 'boolean' ? undefined : options.vsock
-    )))
+    servers.push(
+      new VsockServer(
+        new VsockAddress(
+          typeof options.vsock === 'boolean' ? undefined : options.vsock
+        )
+      )
+    )
   }
   if (options.tcp !== undefined) {
-    servers.push(new TcpServer(new TcpAddress(
-      typeof options.tcp === 'boolean' ? undefined : options.tcp
-    )))
+    servers.push(
+      new TcpServer(
+        new TcpAddress(
+          typeof options.tcp === 'boolean' ? undefined : options.tcp
+        )
+      )
+    )
   }
   if (options.http !== undefined) {
-    servers.push(new HttpServer(new HttpAddress(
-      typeof options.http === 'boolean' ? undefined : options.http
-    )))
+    servers.push(
+      new HttpServer(
+        new HttpAddress(
+          typeof options.http === 'boolean' ? undefined : options.http
+        )
+      )
+    )
   }
   if (options.ws !== undefined) {
-    servers.push(new WebSocketServer(new WebSocketAddress(
-      typeof options.ws === 'boolean' ? undefined : options.ws
-    )))
+    servers.push(
+      new WebSocketServer(
+        new WebSocketAddress(
+          typeof options.ws === 'boolean' ? undefined : options.ws
+        )
+      )
+    )
   }
   if (servers.length === 0) {
     log.warn(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,9 @@ import StdioClient from './stdio/StdioClient'
 import HttpServer from './http/HttpServer'
 import TcpServer from './tcp/TcpServer'
 import WebSocketServer from './ws/WebSocketServer'
-import { HttpAddress, TcpAddress, WebSocketAddress } from './base/Transports'
+import { HttpAddress, TcpAddress, WebSocketAddress, VsockAddress } from './base/Transports'
+import VsockServer from './vsock/VsockServer';
+import StdioServer from './stdio/StdioServer';
 
 const { _: args, ...options } = minimist(process.argv.slice(2))
 
@@ -29,23 +31,28 @@ const main = async () => {
 
   // Add server classes based on supplied options
   const servers: Server[] = []
+  if (options.stdio !== undefined) {
+    servers.push(new StdioServer())
+  }
+  if (options.vsock !== undefined) {
+    servers.push(new VsockServer(new VsockAddress(
+      typeof options.vsock === 'boolean' ? undefined : options.vsock
+    )))
+  }
   if (options.tcp !== undefined) {
-    const address = new TcpAddress(
+    servers.push(new TcpServer(new TcpAddress(
       typeof options.tcp === 'boolean' ? undefined : options.tcp
-    )
-    servers.push(new TcpServer(address))
+    )))
   }
   if (options.http !== undefined) {
-    const address = new HttpAddress(
+    servers.push(new HttpServer(new HttpAddress(
       typeof options.http === 'boolean' ? undefined : options.http
-    )
-    servers.push(new HttpServer(address))
+    )))
   }
   if (options.ws !== undefined) {
-    const address = new WebSocketAddress(
+    servers.push(new WebSocketServer(new WebSocketAddress(
       typeof options.ws === 'boolean' ? undefined : options.ws
-    )
-    servers.push(new WebSocketServer(address))
+    )))
   }
   if (servers.length === 0) {
     log.warn(

--- a/src/direct/DirectClientServer.test.ts
+++ b/src/direct/DirectClientServer.test.ts
@@ -3,28 +3,25 @@ import DirectClient from './DirectClient'
 import DirectServer from './DirectServer'
 import { Executor } from '../base/Executor'
 
-describe('DirectClient and DirectServer', () => {
+test('DirectClient and DirectServer', async () => {
+  const server = new DirectServer()
   const executor = new Executor()
-  const server = new DirectServer(executor)
+  await server.start(executor)
   const client = new DirectClient(server.address)
 
-  test('calling manifest', async () => {
-    expect(await client.manifest()).toEqual(await executor.manifest())
+  expect(await client.manifest()).toEqual(await executor.manifest())
+
+  const node = stencila.person({
+    givenNames: ['Jane'],
+    familyNames: ['Jones']
   })
 
-  test('calling methods with node', async () => {
-    const node = stencila.person({
-      givenNames: ['Jane'],
-      familyNames: ['Jones']
-    })
-
-    for (const method of ['compile', 'build', 'execute']) {
-      // @ts-ignore
-      expect(await client[method](node)).toEqual(node)
-    }
-
-    // There should be no more requests waiting for a response
+  for (const method of ['compile', 'build', 'execute']) {
     // @ts-ignore
-    expect(Object.keys(client.requests).length).toEqual(0)
-  })
+    expect(await client[method](node)).toEqual(node)
+  }
+
+  // There should be no more requests waiting for a response
+  // @ts-ignore
+  expect(Object.keys(client.requests).length).toEqual(0)
 })

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -110,7 +110,6 @@ export default class HttpServer extends TcpServer {
   public async start(executor?: Executor): Promise<void> {
     if (executor === undefined) executor = new Executor()
     this.executor = executor
-    console.log(this.executor)
 
     const url = this.address.toString()
     log.info(`Starting server: ${url}`)

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -9,6 +9,7 @@ import JsonRpcRequest from '../base/JsonRpcRequest'
 import JsonRpcResponse from '../base/JsonRpcResponse'
 import { HttpAddress } from '../base/Transports'
 import TcpServer from '../tcp/TcpServer'
+import { JsonRpcErrorCode } from '../base/JsonRpcError'
 
 const log = getLogger('executa:http:server')
 
@@ -82,7 +83,9 @@ export default class HttpServer extends TcpServer {
         reply.header('Content-Type', 'application/json')
         const { result, error } = jsonRpcResponse
         if (error !== undefined)
-          reply.status(error.code < -32603 ? 400 : 500).send({ error: error })
+          reply
+            .status(error.code < JsonRpcErrorCode.InternalError ? 400 : 500)
+            .send({ error: error })
         else reply.send(result)
       }
     }
@@ -92,6 +95,8 @@ export default class HttpServer extends TcpServer {
     app.post('/compile', wrap('compile'))
     app.post('/build', wrap('build'))
     app.post('/execute', wrap('execute'))
+    app.post('/begin', wrap('begin'))
+    app.post('/end', wrap('end'))
 
     this.server = app.server
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,18 @@
-export * from './base/Executor'
+export {Executor} from './base/Executor'
 
-export * from './stdio/discover'
-export * from './stdio/StdioClient'
-export * from './stdio/StdioServer'
+export {default as stdioDiscover} from './stdio/discover'
+export {default as StdioClient} from './stdio/StdioClient'
+export {default as StdioServer} from './stdio/StdioServer'
 
-export * from './tcp/TcpClient'
-export * from './tcp/TcpServer'
+export {default as VsockFirecrackerClient} from './vsock/VsockFirecrackerClient'
+export {default as VsockServer} from './vsock/VsockServer'
 
-export * from './http/discover'
-export * from './http/HttpClient'
-export * from './http/HttpServer'
+export {default as TcpClient} from './tcp/TcpClient'
+export {default as TcpServer} from './tcp/TcpServer'
 
-export * from './ws/WebSocketClient'
-export * from './ws/WebSocketServer'
+export {default as httpDiscover} from './http/discover'
+export {default as HttpClient} from './http/HttpClient'
+export {default as HttpServer} from './http/HttpServer'
+
+export {default as WebSocketClient} from './ws/WebSocketClient'
+export {default as WebSocketServer} from './ws/WebSocketServer'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,20 @@
-export {Executor} from './base/Executor'
+export { Executor } from './base/Executor'
 
-export {default as stdioDiscover} from './stdio/discover'
-export {default as StdioClient} from './stdio/StdioClient'
-export {default as StdioServer} from './stdio/StdioServer'
+export { default as stdioDiscover } from './stdio/discover'
+export { default as StdioClient } from './stdio/StdioClient'
+export { default as StdioServer } from './stdio/StdioServer'
 
-export {default as VsockFirecrackerClient} from './vsock/VsockFirecrackerClient'
-export {default as VsockServer} from './vsock/VsockServer'
+export {
+  default as VsockFirecrackerClient
+} from './vsock/VsockFirecrackerClient'
+export { default as VsockServer } from './vsock/VsockServer'
 
-export {default as TcpClient} from './tcp/TcpClient'
-export {default as TcpServer} from './tcp/TcpServer'
+export { default as TcpClient } from './tcp/TcpClient'
+export { default as TcpServer } from './tcp/TcpServer'
 
-export {default as httpDiscover} from './http/discover'
-export {default as HttpClient} from './http/HttpClient'
-export {default as HttpServer} from './http/HttpServer'
+export { default as httpDiscover } from './http/discover'
+export { default as HttpClient } from './http/HttpClient'
+export { default as HttpServer } from './http/HttpServer'
 
-export {default as WebSocketClient} from './ws/WebSocketClient'
-export {default as WebSocketServer} from './ws/WebSocketServer'
+export { default as WebSocketClient } from './ws/WebSocketClient'
+export { default as WebSocketServer } from './ws/WebSocketServer'

--- a/src/stdio/StdioClient.ts
+++ b/src/stdio/StdioClient.ts
@@ -20,10 +20,6 @@ export default class StdioClient extends StreamClient {
     }
 
     const child = spawn(command, args)
-    const { stdin, stdout, stderr } = child
-    if (stdout === null || stdin === null || stderr === null)
-      throw new Error('STDIO is not set up right')
-
     child.on('error', (error: Error) => log.error(error))
     child.on('exit', (code: number | null, signal: string | null) =>
       log.error(
@@ -31,7 +27,9 @@ export default class StdioClient extends StreamClient {
       )
     )
 
+    const { stdin, stdout } = child
     super(stdin, stdout)
+
     this.child = child
   }
 
@@ -39,7 +37,7 @@ export default class StdioClient extends StreamClient {
    * Stop the child server process
    */
   stop() {
-    // Avoid uneccessary log errors by removing listener
+    // Avoid unnecessary log errors by removing listener
     this.child.removeAllListeners('exit')
     this.child.kill()
   }

--- a/src/stdio/StdioClient.ts
+++ b/src/stdio/StdioClient.ts
@@ -27,8 +27,11 @@ export default class StdioClient extends StreamClient {
       )
     )
 
-    const { stdin, stdout } = child
+    // Use stdin and stout for transport and pipe stderr to
+    // stderr of current process
+    const { stdin, stdout, stderr } = child
     super(stdin, stdout)
+    stderr.pipe(process.stderr)
 
     this.child = child
   }

--- a/src/stdio/dockerServer.e2e.ts
+++ b/src/stdio/dockerServer.e2e.ts
@@ -3,7 +3,7 @@ import { testClient } from '../test/testClient'
 
 jest.setTimeout(30 * 1000)
 
-test('run a StdioServer inside a Docker an communicate with it', async () => {
+test('run a StdioServer inside a Docker container', async () => {
   // Use `interactive` option so that STDIN is kept open.
   // Also means that the container stops when the client is stopped.
   const client = new StdioClient(`docker run --interactive stencila/executa`)

--- a/src/stdio/dockerServer.e2e.ts
+++ b/src/stdio/dockerServer.e2e.ts
@@ -1,0 +1,12 @@
+import StdioClient from './StdioClient'
+import { testClient } from '../test/testClient'
+
+jest.setTimeout(30 * 1000)
+
+test('run a StdioServer inside a Docker an communicate with it', async () => {
+  // Use `interactive` option so that STDIN is kept open.
+  // Also means that the container stops when the client is stopped.
+  const client = new StdioClient(`docker run --interactive stencila/executa`)
+  await testClient(client)
+  client.stop()
+})

--- a/src/stream/StreamClientServer.test.ts
+++ b/src/stream/StreamClientServer.test.ts
@@ -5,13 +5,12 @@ import StreamServer from './StreamServer'
 import { Executor } from '../base/Executor'
 
 describe('StreamClient and StreamServer', () => {
-  const executor = new Executor()
-
   // @ts-ignore Ignore the fact that this is an abstract class
-  const server = new StreamServer(executor)
+  const server = new StreamServer()
+  const executor = new Executor()
   const serverIncoming = new PassThrough()
   const serverOutgoing = new PassThrough()
-  server.start(serverIncoming, serverOutgoing)
+  server.start(executor, serverIncoming, serverOutgoing)
 
   // @ts-ignore Ignore the fact that this is an abstract class
   const client = new StreamClient(serverIncoming, serverOutgoing)

--- a/src/stream/StreamServer.ts
+++ b/src/stream/StreamServer.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import * as lps from 'length-prefixed-stream'
 import { Readable, Writable } from 'stream'
+import { Executor } from '../base/Executor'
 import Server from '../base/Server'
 export default abstract class StreamServer extends Server {
   /**
@@ -8,10 +9,13 @@ export default abstract class StreamServer extends Server {
    */
   private encoder: lps.Encoder
 
-  public start(
+  public async start(
+    executor?: Executor,
     incoming: Readable = process.stdin,
     outgoing: Writable = process.stdout
   ): Promise<void> {
+    await super.start(executor)
+
     const decoder = lps.decode()
     incoming.pipe(decoder)
     decoder.on('data', async (data: Buffer) => {
@@ -22,7 +26,5 @@ export default abstract class StreamServer extends Server {
 
     this.encoder = lps.encode()
     this.encoder.pipe(outgoing)
-
-    return Promise.resolve()
   }
 }

--- a/src/tcp/TcpServer.ts
+++ b/src/tcp/TcpServer.ts
@@ -15,11 +15,8 @@ export default class TcpServer extends StreamServer {
 
   protected clients: Socket[] = []
 
-  public constructor(
-    executor?: Executor,
-    address: TcpAddress = new TcpAddress()
-  ) {
-    super(executor)
+  public constructor(address: TcpAddress = new TcpAddress()) {
+    super()
 
     const { host, port } = address
     this.host = host
@@ -40,12 +37,12 @@ export default class TcpServer extends StreamServer {
     })
   }
 
-  public async start(): Promise<void> {
+  public async start(executor?: Executor): Promise<void> {
     if (this.server === undefined) {
       log.info(`Starting server: ${this.address.toString()}`)
 
       const server = (this.server = createServer(socket => {
-        super.start(socket, socket).catch(e => {
+        super.start(executor, socket, socket).catch(e => {
           log.error(
             `Failed to start server: ${this.address.toString()}\n\n${e}`
           )

--- a/src/vsock/VsockFirecrackerClient.ts
+++ b/src/vsock/VsockFirecrackerClient.ts
@@ -2,6 +2,7 @@ import { getLogger } from '@stencila/logga'
 import net from 'net'
 import { VsockAddress } from '../base/Transports'
 import StreamClient from '../stream/StreamClient'
+import { InternalError } from '../base/InternalError'
 
 const log = getLogger('executa:vsock:client')
 
@@ -10,7 +11,7 @@ export default class VsockFirecrackerClient extends StreamClient {
 
   public constructor(address: VsockAddress = new VsockAddress()) {
     const { path, port } = address
-    if (path === undefined) throw new Error(`Path is required`)
+    if (path === undefined) throw new InternalError(`Path is required`)
 
     const socket = net.connect(path)
     socket.on('connect', () => {

--- a/src/vsock/VsockServer.ts
+++ b/src/vsock/VsockServer.ts
@@ -12,11 +12,8 @@ export default class VsockServer extends StreamServer {
 
   private server?: ChildProcess
 
-  public constructor(
-    executor?: Executor,
-    address: VsockAddress = new VsockAddress()
-  ) {
-    super(executor)
+  public constructor(address: VsockAddress = new VsockAddress()) {
+    super()
 
     this.port = address.port
   }
@@ -25,14 +22,14 @@ export default class VsockServer extends StreamServer {
     return new VsockAddress(this.port)
   }
 
-  public async start(): Promise<void> {
+  public async start(executor?: Executor): Promise<void> {
     if (this.server === undefined) {
       const server = (this.server = spawn(
         path.join(__dirname, 'vsock-server'),
         [`${this.port}`]
       ))
       server.on('error', err => log.error(err))
-      return super.start(server.stdout, server.stdin)
+      return super.start(executor, server.stdout, server.stdin)
     }
   }
 

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -2,9 +2,9 @@ import { getLogger } from '@stencila/logga'
 // @ts-ignore
 import fastifyWebsocket from 'fastify-websocket'
 import jwt from 'jsonwebtoken'
+import { InternalError } from '../base/InternalError'
+import { WebSocketAddress } from '../base/Transports'
 import HttpServer from '../http/HttpServer'
-import { WebSocketAddress, TcpAddressInitializer } from '../base/Transports'
-import { Executor } from '../base/Executor'
 
 const log = getLogger('executa:ws:server')
 
@@ -12,16 +12,13 @@ const log = getLogger('executa:ws:server')
  * A `Server` using WebSockets for communication.
  */
 export default class WebSocketServer extends HttpServer {
-  public constructor(
-    executor?: Executor,
-    address: WebSocketAddress = new WebSocketAddress()
-  ) {
-    super(executor, address)
+  public constructor(address: WebSocketAddress = new WebSocketAddress()) {
+    super(address)
 
     // Apply JWT-based authorization of each connection
     const secret = process.env.JWT_SECRET
     if (secret === undefined)
-      throw new Error('Environment variable JWT_SECRET must be set')
+      throw new InternalError('Environment variable JWT_SECRET must be set')
     const authorize = (info: any, next: (ok: boolean) => void) => {
       const token = info.req.headers['sec-websocket-protocol']
       if (token !== undefined) {

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -2,8 +2,7 @@
   "extends": "@stencila/dev-config/tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "node",
-    "module": "esnext",
-    "outDir": "dist"
+    "module": "esnext"
   },
   "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@stencila/dev-config/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist/lib"
   },
-  "include": ["src/**/*.ts"]
+  "files": ["src/index.ts", "src/cli.ts", "src/console.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "dist/lib"
   },
-  "files": ["src/index.ts", "src/cli.ts", "src/console.ts"]
+  "files": ["src/index.ts", "src/cli.ts", "src/console.ts"],
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This PR introduces changes found necessary for using Executa within Sparkla (as a base class for `Manager` and for running inside containers).