### PR TITLE
Refactoring of key method signatures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,32 @@
       "program": "${workspaceFolder}/index.js",
       "preLaunchTask": "tsc: build - tsconfig.json",
       "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1522,12 +1522,23 @@
       "integrity": "sha512-xHSE0IAn+LmOBX8JnhTsTqbECYaNc7rzNDDMaMyAeS8UL8zOYCwIwChMD1lIDJXkHi5KCxIiFUQiLhq0Ujy/ig=="
     },
     "@stencila/schema": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.29.0.tgz",
-      "integrity": "sha512-fi32ZZ4uRMh1qk5UTrRp5HXl6NE26M9Ml98aaaqeqr6qX/zQoL/aTPUNj/cO/v6tcgQ5kXfs0Vk0Wn4qjctjqg==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.30.4.tgz",
+      "integrity": "sha512-Nx8VzzEEzjSE4Fm974I0jbz6aZ+zaV6+qAcicFSLILAbqLuhdG9DTfYch1jVeBXkbRYqeulzJsniRWHEIC2bIA==",
       "requires": {
+        "acorn": "^7.1.0",
         "astring": "^1.4.1",
-        "meriyah": "^1.6.10"
+        "get-stdin": "^7.0.0",
+        "length-prefixed-stream": "^2.0.0",
+        "logga": "^1.1.0",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
+        }
       }
     },
     "@stencila/semantic-release-config": {
@@ -1878,8 +1889,7 @@
     "acorn": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-      "dev": true
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -2260,9 +2270,9 @@
       "dev": true
     },
     "astring": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.4.2.tgz",
-      "integrity": "sha512-AmMytzXJ3p1dC0jfXUxH2AO0b8IsoOFKj160kVMUvUtajJl6S8EO3VYPod1TM2Xdvzf8p/Jh0Tx3ZkgdYMCsqw=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.4.3.tgz",
+      "integrity": "sha512-yJlJU/bmN820vL+cbWShu2YQU87dBP5V7BH2N4wODapRv27A2dZtUD0LgjP9lZENvPe9XRoSyWx+pZR6qKqNBw=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -8690,6 +8700,21 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
+    "logga": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/logga/-/logga-1.1.0.tgz",
+      "integrity": "sha1-B4I1eXDw82agX93gDK6Bp5PyAnA=",
+      "requires": {
+        "colors": "~0.6.0-1"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+        }
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8956,11 +8981,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
       "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
-    },
-    "meriyah": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-1.8.2.tgz",
-      "integrity": "sha512-8D2Kdx9HXXxG7G7pg9DNBXQn22PxRO2zNqu+6Q2u5ho6tep79tp/DKVCUjGZz/jBnT4kx5/siP7X3BiOXg3Smg=="
     },
     "micromatch": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1522,9 +1522,9 @@
       "integrity": "sha512-xHSE0IAn+LmOBX8JnhTsTqbECYaNc7rzNDDMaMyAeS8UL8zOYCwIwChMD1lIDJXkHi5KCxIiFUQiLhq0Ujy/ig=="
     },
     "@stencila/schema": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.30.4.tgz",
-      "integrity": "sha512-Nx8VzzEEzjSE4Fm974I0jbz6aZ+zaV6+qAcicFSLILAbqLuhdG9DTfYch1jVeBXkbRYqeulzJsniRWHEIC2bIA==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.30.5.tgz",
+      "integrity": "sha512-O9O9FBt9C8D85nA6sP4VVfQL231rbA3sTKL5/DDf9WSTes4oY0mdoWs5S+y5guhoJWkZY8RIwB9JILYff7mkSw==",
       "requires": {
         "acorn": "^7.1.0",
         "astring": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@stencila/logga": "^1.4.0",
-    "@stencila/schema": "^0.29.0",
+    "@stencila/schema": "^0.30.4",
     "@types/ws": "^6.0.3",
     "ajv": "^6.10.2",
     "cross-fetch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@stencila/logga": "^1.4.0",
-    "@stencila/schema": "^0.30.4",
+    "@stencila/schema": "^0.30.5",
     "@types/ws": "^6.0.3",
     "ajv": "^6.10.2",
     "cross-fetch": "^3.0.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default [
             'nodeType',
             'isPrimitive',
             'codeChunk',
-            'environment',
+            'softwareEnvironment',
             'softwareSession'
           ]
         }

--- a/src/base/BaseExecutor.ts
+++ b/src/base/BaseExecutor.ts
@@ -1,0 +1,504 @@
+import { getLogger } from '@stencila/logga'
+import { isPrimitive, Node, nodeType, SoftwareSession } from '@stencila/schema'
+import Ajv from 'ajv'
+import { ClientType } from './Client'
+import { InternalError } from './InternalError'
+import { Server } from './Server'
+import { Transport } from './Transports'
+import { Executor, Method, Manifest, Capabilities, Addresses } from './Executor'
+
+const log = getLogger('executa:executor')
+
+const ajv = new Ajv()
+
+/**
+ * A function that can be called to obtain
+ * a list of potential peer `Executors`
+ */
+type DiscoveryFunction = () => Promise<Manifest[]>
+
+/**
+ * A instance of a `Executor` used as a peer
+ * to delegate method calls to.
+ */
+export class Peer {
+  /**
+   * The manifest of the peer executor.
+   */
+  public readonly manifest: Manifest
+
+  /**
+   * A list of classes, that extend `Client`, and are available
+   * to connect to peer executors.
+   *
+   * This property is used for dependency injection, rather than importing
+   * clients for all transports into this module when they may
+   * not be used (e.g. `StdioClient` in a browser hosted `Executor`).
+   * The order of this list, defines the preference for the transport.
+   */
+  public readonly clientTypes: ClientType[]
+
+  /**
+   * The interface to the peer executor.
+   *
+   * May be an in-process `Executor` or a `Client` to an out-of-process
+   * `Executor`, in which case it's type e.g. `StdioClient` vs `WebSocketClient`
+   * will depend upon the available transports in `manifest.addresses`.
+   */
+  private interface?: Executor
+
+  /**
+   * Ajv validation functions for each method.
+   *
+   * Validation functions are just-in-time compiled
+   * in the `capable` method.
+   */
+  private validators: { [key: string]: Ajv.ValidateFunction[] } = {}
+
+  public constructor(manifest: Manifest, clientTypes: ClientType[]) {
+    this.manifest = manifest
+    this.clientTypes = clientTypes
+  }
+
+  /**
+   * Test whether the peer is capable of executing the
+   * method with the supplied parameters.
+   *
+   * Just-in-time compiles the JSON Schema for each capability
+   * into a validator function that is used to "validate"
+   * the parameters.
+   *
+   * @param method The method to be called
+   * @param params The parameter values of the call
+   */
+  public capable(method: Method, params: { [key: string]: unknown }): boolean {
+    let validators = this.validators[method]
+    if (validators === undefined) {
+      // Peer does not have any capabilities defined
+      if (this.manifest.capabilities === undefined) return false
+
+      let capabilities = this.manifest.capabilities[method]
+      // Peer does not have any capabilities for this method defined
+      if (capabilities === undefined) return false
+
+      // Peer defines capability as a single JSON Schema definition
+      if (!Array.isArray(capabilities)) capabilities = [capabilities]
+
+      // Compile JSON Schema definitions to validation functions
+      validators = this.validators[method] = capabilities.map(schema =>
+        ajv.compile(schema)
+      )
+    }
+    for (const validator of validators) {
+      if (validator(params) === true) return true
+    }
+    return false
+  }
+
+  /**
+   * Connect to the `Executor`.
+   *
+   * Finds the first client type that the peer
+   * executor supports.
+   *
+   * @returns A client instance or `undefined` if not able to connect
+   */
+  public connect(): boolean {
+    // Check if already connected
+    if (this.interface !== undefined) return true
+
+    // If the executor is in-process, just use it directly
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    if (this.manifest.executor instanceof BaseExecutor) {
+      this.interface = this.manifest.executor
+      return true
+    }
+
+    // Connect to remote executor in order of preference of
+    // transports
+    for (const ClientType of this.clientTypes) {
+      // Get the transport for the client type
+      // There should be a better way to do this
+      const transportMap: { [key: string]: Transport } = {
+        DirectClient: Transport.direct,
+        StdioClient: Transport.stdio,
+        VsockClient: Transport.vsock,
+        TcpClient: Transport.tcp,
+        HttpClient: Transport.http,
+        WebSocketClient: Transport.ws
+      }
+      const transport = transportMap[ClientType.name]
+      if (transport === undefined)
+        throw new InternalError(
+          `Wooah! A key is missing for "${ClientType.name}" in transportMap.`
+        )
+
+      // See if the peer has an address for the transport
+      if (this.manifest.addresses === undefined) return false
+      const address = this.manifest.addresses[transport]
+      if (address !== undefined) {
+        this.interface = new ClientType(address)
+        return true
+      }
+    }
+    // Unable to connect to the peer
+    return false
+  }
+
+  /**
+   * Call a method of a remote `Executor`.
+   *
+   * Ensures that there is a connection to the
+   * executor and then passes the request to it.
+   *
+   * @param method The name of the method
+   * @param params Values of parameters (i.e. arguments)
+   */
+  public async call<Type>(
+    method: Method,
+    params: { [key: string]: any } = {}
+  ): Promise<Type> {
+    if (this.interface === undefined)
+      throw new InternalError(
+        "WTF, no client! You shouldn't be calling this yet!"
+      )
+    return this.interface.call<Type>(method, params)
+  }
+}
+
+/**
+ * A base `Executor` class implementation.
+ *
+ * This executor class has limited capabilities itself and
+ * instead, mostly delegates to other executors. If unable
+ * to delegate to a peer, then falls back to returning
+ * the `Node` unchanged (for `compile`, `build` etc) or
+ * attempting to use JSON as format (for `decode` and `encode`).
+ */
+export class BaseExecutor implements Executor {
+  /**
+   * Functions used to obtain manifests of potential
+   * peer executors.
+   */
+  private readonly discoveryFunctions: DiscoveryFunction[]
+
+  /**
+   * Classes of `Client` that this executor is able
+   * to use to connect to peer executors.
+   */
+  private readonly clientTypes: ClientType[]
+
+  /**
+   * Peer executors that are delegated to depending
+   * upon their capabilities and the request at hand.
+   *
+   * This list is just-in-time populated when a request
+   * is made to the executor that it needs to delegate,
+   * or by explicitly calling `discover()`.
+   */
+  private peers?: Peer[]
+
+  /**
+   * Servers that will pass on requests to this executor.
+   */
+  private readonly servers: Server[] = []
+
+  public constructor(
+    discoveryFunctions: DiscoveryFunction[] = [],
+    clientTypes: ClientType[] = [],
+    servers: Server[] = []
+  ) {
+    this.discoveryFunctions = discoveryFunctions
+    this.clientTypes = clientTypes
+    this.servers = servers
+  }
+
+  /**
+   * Start servers for the executor.
+   */
+  public async start(): Promise<void> {
+    if (this.servers.length === 0) {
+      log.warn('No servers configured; executor will not be accessible.')
+      return
+    }
+
+    log.info(
+      `Starting servers: ${this.servers
+        .map(server => server.address.type)
+        .join(', ')}`
+    )
+    await Promise.all(this.servers.map(server => server.start(this)))
+  }
+
+  /**
+   * Stop servers for the executor.
+   */
+  public async stop(): Promise<void> {
+    log.info('Stopping servers')
+    await Promise.all(this.servers.map(server => server.stop()))
+  }
+
+  /**
+   * Get the manifest of the executor
+   *
+   * Derived classes may override this method,
+   * but will normally just override `capabilities()`.
+   */
+  public async manifest(): Promise<Manifest> {
+    return {
+      capabilities: await this.capabilities(),
+      addresses: this.addresses()
+    }
+  }
+
+  /**
+   * Get the capabilities of the executor
+   *
+   * Derived classes will usually override this method
+   * to declare additional node types that methods such
+   * as `compile` and `execute` can handle.
+   */
+  protected async capabilities(): Promise<Capabilities> {
+    // Define the capabilities that this executor
+    // has without needing to delegate
+    const capabilities: Capabilities = {
+      decode: [
+        // Can decode string content of JSON format
+        {
+          properties: {
+            content: { type: 'string' },
+            format: { const: 'json' }
+          },
+          required: ['content']
+        }
+      ],
+      encode: [
+        // Can encode any node to JSON format
+        {
+          properties: {
+            node: true,
+            format: { const: 'json' }
+          },
+          required: ['node']
+        }
+      ]
+    }
+
+    // Do peer discovery if not yet done
+    if (this.peers === undefined) await this.discover()
+    // This may be able to be removed with assert signatures in TS 3.7
+    if (this.peers === undefined)
+      throw new InternalError(
+        `Whaaaat! How can this be, peers are still undefined!?`
+      )
+
+    // Merge in the capabilities of peer executors
+    for (const peer of this.peers) {
+      const manifest = peer.manifest
+      if (manifest.capabilities === undefined) continue
+      for (const [method, additional] of Object.entries(
+        manifest.capabilities
+      )) {
+        const current = capabilities[method]
+        capabilities[method] = [
+          ...(Array.isArray(current) ? current : [current]),
+          ...(Array.isArray(additional) ? additional : [additional])
+        ]
+      }
+    }
+
+    return capabilities
+  }
+
+  /**
+   * Get a map of server addresses for this executor.
+   */
+  public addresses(): Addresses {
+    return this.servers
+      .map(server => server.address)
+      .reduce((prev, curr) => ({ ...prev, ...{ [curr.type]: curr } }), {})
+  }
+
+  public async decode(content: string, format = 'json'): Promise<Node> {
+    if (format === 'json') return JSON.parse(content)
+    return this.delegate(Method.decode, { content, format }, () =>
+      this.decode(content, 'json')
+    )
+  }
+
+  public async encode(node: Node, format = 'json'): Promise<string> {
+    if (format === 'json') return JSON.stringify(node)
+    return this.delegate(Method.encode, { node, format }, () =>
+      this.encode(node, 'json')
+    )
+  }
+
+  public async compile<NodeType extends Node>(
+    node: NodeType
+  ): Promise<NodeType> {
+    return this.delegate(Method.compile, { node }, () => Promise.resolve(node))
+  }
+
+  public async build<NodeType extends Node>(node: NodeType): Promise<NodeType> {
+    return this.delegate(Method.build, { node }, () => Promise.resolve(node))
+  }
+
+  /**
+   * Execute a `Node`.
+   *
+   * Walks the node tree and attempts to delegate
+   * execution of certain types of nodes
+   * (currently `CodeChunk` and `CodeExpression`).
+   *
+   * @param node The node to execute
+   * @param session The session to execute the node within
+   */
+  public execute<NodeType extends Node>(
+    node: NodeType,
+    session?: SoftwareSession
+  ): Promise<NodeType> {
+    return this.walk(node, node => {
+      switch (nodeType(node)) {
+        case 'CodeChunk':
+        case 'CodeExpression':
+          return this.delegate(Method.execute, { node, session }, () =>
+            Promise.resolve({
+              ...(node as object),
+              errors: [
+                {
+                  type: 'CodeError',
+                  kind: 'incapable',
+                  message: 'Not able to execute this type of code.'
+                }
+              ]
+            })
+          )
+      }
+      return Promise.resolve(node)
+    })
+  }
+
+  /**
+   * Begin running a `Node`.
+   */
+  public begin<NodeType extends Node>(
+    node: NodeType,
+    limits?: SoftwareSession
+  ): Promise<NodeType> {
+    return this.delegate(Method.begin, { node, limits }, () =>
+      Promise.resolve(node)
+    )
+  }
+
+  /**
+   * End running a `Node`.
+   */
+  public end<NodeType extends Node>(node: NodeType): Promise<NodeType> {
+    return this.delegate(Method.end, { node }, () => Promise.resolve(node))
+  }
+
+  public async call(
+    method: Method,
+    params: { [key: string]: any }
+  ): Promise<any> {
+    switch (method) {
+      case Method.decode:
+        return this.decode(params.content, params.format)
+      case Method.encode:
+        return this.encode(params.node, params.format)
+      case Method.compile:
+        return this.compile(params.node)
+      case Method.build:
+        return this.build(params.node)
+      case Method.execute:
+        return this.execute(params.node, params.session)
+    }
+  }
+
+  private async walk<NodeType extends Node>(
+    root: NodeType,
+    transformer: (node: Node) => Promise<Node>
+  ): Promise<NodeType> {
+    return walk(root) as Promise<NodeType>
+    async function walk(node: Node): Promise<Node> {
+      const transformed = await transformer(node)
+
+      if (transformed !== node) return transformed
+
+      if (transformed === undefined || isPrimitive(transformed))
+        return transformed
+      if (Array.isArray(transformed)) return Promise.all(transformed.map(walk))
+      return Object.entries(transformed).reduce(
+        async (prev, [key, child]) => ({
+          ...(await prev),
+          ...{ [key]: await walk(child) }
+        }),
+        Promise.resolve({})
+      )
+    }
+  }
+
+  /**
+   * Discover peers by calling discovery functions.
+   *
+   * This gets called just-in-time, but you may also want to
+   * call it ahead-of-time to reduce latency
+   * in the first method call.
+   */
+  private async discover(): Promise<void> {
+    log.info(`Discovering peers`)
+
+    // Get the list of manifests
+    const manifests = await this.discoveryFunctions.reduce(
+      async (all: Promise<Manifest[]>, discoveryFunction) => {
+        return [...(await all), ...(await discoveryFunction())]
+      },
+      Promise.resolve([])
+    )
+
+    if (manifests.length === 0) {
+      log.warn(
+        'No peer executors discovered. Executor will have limited capabilities.'
+      )
+    }
+
+    // Create a list of peers
+    this.peers = manifests.map(manifest => new Peer(manifest, this.clientTypes))
+  }
+
+  /**
+   * Delegate a method call to a peer.
+   *
+   * @param method The method name
+   * @param params The parameter values (i.e. the arguments)
+   * @param fallback A fallback function called if unable to delegate
+   */
+  private async delegate<Type>(
+    method: Method,
+    params: { [key: string]: any },
+    fallback: () => Promise<Type>
+  ): Promise<Type> {
+    log.debug(`Delegating: ${method}(${Object.keys(params).join(', ')})`)
+
+    // Do peer discovery if not yet done
+    if (this.peers === undefined) await this.discover()
+    // This may be able to be removed with assert signatures in TS 3.7
+    if (this.peers === undefined)
+      throw new InternalError(
+        `Whaaaat! How can this be, peers are still undefined!?`
+      )
+
+    // Attempt to delegate to a peer
+    for (const peer of this.peers) {
+      if (peer.capable(method, params)) {
+        if (peer.connect()) {
+          return peer.call<Type>(method, params)
+        }
+      }
+    }
+
+    // No peer has necessary capability so resort to fallback
+    log.debug(`Unable to delegate node: ${JSON.stringify(params)} `)
+    return fallback()
+  }
+}

--- a/src/base/Client.ts
+++ b/src/base/Client.ts
@@ -132,6 +132,15 @@ export abstract class Client implements Interface {
     resolve(response)
     delete this.requests[response.id]
   }
+
+  /**
+   * Stop the client
+   *
+   * Derived classes may override this method.
+   */
+  public stop(): Promise<void> {
+    return Promise.resolve()
+  }
 }
 
 export interface ClientType {

--- a/src/base/Client.ts
+++ b/src/base/Client.ts
@@ -1,5 +1,5 @@
 import { Node, SoftwareSession } from '@stencila/schema'
-import { Interface, Manifest, Method } from './Executor'
+import { Executor, Manifest, Method } from './Executor'
 import { JsonRpcError, JsonRpcErrorCode } from './JsonRpcError'
 import { JsonRpcRequest } from './JsonRpcRequest'
 import { JsonRpcResponse } from './JsonRpcResponse'
@@ -10,7 +10,7 @@ import { JsonRpcResponse } from './JsonRpcResponse'
  * Implements asynchronous, methods for `Executor` methods `compile`, `build`, `execute`, etc.
  * which send JSON-RPC requests to a `Server` that is serving the remote `Executor`.
  */
-export abstract class Client implements Interface {
+export abstract class Client implements Executor {
   /**
    * A map of requests to which responses can be paired against
    */
@@ -40,36 +40,44 @@ export abstract class Client implements Interface {
   /**
    * Call the remote `Executor`'s `compile` method
    */
-  public async compile(node: Node): Promise<Node> {
-    return this.call<Node>(Method.compile, { node })
+  public async compile<NodeType extends Node>(
+    node: NodeType
+  ): Promise<NodeType> {
+    return this.call<NodeType>(Method.compile, { node })
   }
 
   /**
    * Call the remote `Executor`'s `build` method
    */
-  public async build(node: Node): Promise<Node> {
-    return this.call<Node>(Method.build, { node })
+  public async build<NodeType extends Node>(node: NodeType): Promise<NodeType> {
+    return this.call<NodeType>(Method.build, { node })
   }
 
   /**
    * Call the remote `Executor`'s `execute` method
    */
-  public async execute(node: Node, session?: SoftwareSession): Promise<Node> {
-    return this.call<Node>(Method.execute, { node, session })
+  public async execute<NodeType extends Node>(
+    node: NodeType,
+    session?: SoftwareSession
+  ): Promise<NodeType> {
+    return this.call<NodeType>(Method.execute, { node, session })
   }
 
   /**
    * Call the remote `Executor`'s `begin` method
    */
-  public async begin(node: Node): Promise<Node> {
-    return this.call<Node>(Method.begin, { node })
+  public async begin<NodeType extends Node>(
+    node: NodeType,
+    limits?: SoftwareSession
+  ): Promise<NodeType> {
+    return this.call<NodeType>(Method.begin, { node, limits })
   }
 
   /**
    * Call the remote `Executor`'s `end` method
    */
-  public async end(node: Node): Promise<Node> {
-    return this.call<Node>(Method.end, { node })
+  public async end<NodeType extends Node>(node: NodeType): Promise<NodeType> {
+    return this.call<NodeType>(Method.end, { node })
   }
 
   /**

--- a/src/base/Executor.ts
+++ b/src/base/Executor.ts
@@ -1,13 +1,6 @@
-import { getLogger } from '@stencila/logga'
-import { isPrimitive, Node, nodeType, SoftwareSession } from '@stencila/schema'
-import Ajv from 'ajv'
 import { JSONSchema7Definition } from 'json-schema'
-import { ClientType } from './Client'
-import { InternalError } from './InternalError'
-import { Server } from './Server'
-import { Address, Transport } from './Transports'
-
-const log = getLogger('executa:executor')
+import { Address } from './Transports'
+import { Node, SoftwareSession } from '@stencila/schema'
 
 /**
  * The methods of an `Executor` class.
@@ -68,15 +61,9 @@ export interface Manifest {
 }
 
 /**
- * A function that can be called to obtain
- * a list of potential peer `Executors`
- */
-type DiscoveryFunction = () => Promise<Manifest[]>
-
-/**
  * Interface for `Executor` classes and their proxies.
  */
-export abstract class Interface {
+export abstract class Executor {
   /**
    * Get the manifest of the executor
    *
@@ -101,7 +88,7 @@ export abstract class Interface {
    * @param format The format to encode
    * @returns The node encoded in the format
    */
-  abstract async encode(node: Node, format?: string): Promise<Node>
+  abstract async encode(node: Node, format?: string): Promise<string>
 
   /**
    * Compile a `Node`.
@@ -109,7 +96,9 @@ export abstract class Interface {
    * @param node The node to compile
    * @returns The compiled node
    */
-  abstract async compile(node: Node): Promise<Node>
+  abstract async compile<NodeType extends Node>(
+    node: NodeType
+  ): Promise<NodeType>
 
   /**
    * Build a `Node`.
@@ -117,32 +106,49 @@ export abstract class Interface {
    * @param node The node to build
    * @returns The build node
    */
-  abstract async build(node: Node): Promise<Node>
+  abstract async build<NodeType extends Node>(node: NodeType): Promise<NodeType>
 
   /**
    * Execute a `Node`.
    *
    * @param node The node to execute
    * @param session The session that the node will be executed in
-   * @returns The executed node
+   * @returns The node, with updated properties, after it has been executed
    */
-  abstract async execute(node: Node, session?: SoftwareSession): Promise<Node>
+  abstract async execute<NodeType extends Node>(
+    node: NodeType,
+    session?: SoftwareSession
+  ): Promise<NodeType>
 
   /**
    * Begin running a `Node`.
    *
-   * @param node The node to run
-   * @returns The node after it has begun running
+   * This method keeps a document "running", usually to allow it to react
+   * to changes within it. Compare this to `execute()` which will not wait
+   * and will simply execute all nodes in the document.
+   * The document will keep running until the `end()` method is called on it.
+   *
+   * Usually this method is called with a `SoftwareSession` as the
+   * `node` argument. However, it could also be called with another `Node`
+   * type, e.g. an `Article`, in which case the executor may begin it's
+   * `session` property, or default session if that property is missing.
+   *
+   * @param node The node to run, usually but not necessarily, a `SoftwareSession`
+   * @param limits The limits on the `SoftwareSession` to be started, described as a `SoftwareSession`.
+   * @returns The node, with updated properties, after it has begun running
    */
-  abstract async begin(node: Node): Promise<Node>
+  abstract async begin<NodeType extends Node>(
+    node: NodeType,
+    limits?: SoftwareSession
+  ): Promise<NodeType>
 
   /**
    * End running a `Node`.
    *
-   * @param node The running node
-   * @returns The node after it has ended running
+   * @param node The running node, usually but not necessarily, a `SoftwareSession`
+   * @returns The node, with updated properties, after it has ended running
    */
-  abstract async end(node: Node): Promise<Node>
+  abstract async end<NodeType extends Node>(node: NodeType): Promise<NodeType>
 
   /**
    * Call one of the above methods.
@@ -154,482 +160,4 @@ export abstract class Interface {
     method: Method,
     params: { [key: string]: any }
   ): Promise<Type>
-}
-
-const ajv = new Ajv()
-
-/**
- * A instance of a `Executor` used as a peer
- * to delegate method calls to.
- */
-export class Peer {
-  /**
-   * The manifest of the peer executor.
-   */
-  public readonly manifest: Manifest
-
-  /**
-   * A list of classes, that extend `Client`, and are available
-   * to connect to peer executors.
-   *
-   * This property is used for dependency injection, rather than importing
-   * clients for all transports into this module when they may
-   * not be used (e.g. `StdioClient` in a browser hosted `Executor`).
-   * The order of this list, defines the preference for the transport.
-   */
-  public readonly clientTypes: ClientType[]
-
-  /**
-   * The interface to the peer executor.
-   *
-   * May be an in-process `Executor` or a `Client` to an out-of-process
-   * `Executor`, in which case it's type e.g. `StdioClient` vs `WebSocketClient`
-   * will depend upon the available transports in `manifest.addresses`.
-   */
-  private interface?: Interface
-
-  /**
-   * Ajv validation functions for each method.
-   *
-   * Validation functions are just-in-time compiled
-   * in the `capable` method.
-   */
-  private validators: { [key: string]: Ajv.ValidateFunction[] } = {}
-
-  public constructor(manifest: Manifest, clientTypes: ClientType[]) {
-    this.manifest = manifest
-    this.clientTypes = clientTypes
-  }
-
-  /**
-   * Test whether the peer is capable of executing the
-   * method with the supplied parameters.
-   *
-   * Just-in-time compiles the JSON Schema for each capability
-   * into a validator function that is used to "validate"
-   * the parameters.
-   *
-   * @param method The method to be called
-   * @param params The parameter values of the call
-   */
-  public capable(method: Method, params: { [key: string]: unknown }): boolean {
-    let validators = this.validators[method]
-    if (validators === undefined) {
-      // Peer does not have any capabilities defined
-      if (this.manifest.capabilities === undefined) return false
-
-      let capabilities = this.manifest.capabilities[method]
-      // Peer does not have any capabilities for this method defined
-      if (capabilities === undefined) return false
-
-      // Peer defines capability as a single JSON Schema definition
-      if (!Array.isArray(capabilities)) capabilities = [capabilities]
-
-      // Compile JSON Schema definitions to validation functions
-      validators = this.validators[method] = capabilities.map(schema =>
-        ajv.compile(schema)
-      )
-    }
-    for (const validator of validators) {
-      if (validator(params) === true) return true
-    }
-    return false
-  }
-
-  /**
-   * Connect to the `Executor`.
-   *
-   * Finds the first client type that the peer
-   * executor supports.
-   *
-   * @returns A client instance or `undefined` if not able to connect
-   */
-  public connect(): boolean {
-    // Check if already connected
-    if (this.interface !== undefined) return true
-
-    // If the executor is in-process, just use it directly
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    if (this.manifest.executor instanceof Executor) {
-      this.interface = this.manifest.executor
-      return true
-    }
-
-    // Connect to remote executor in order of preference of
-    // transports
-    for (const ClientType of this.clientTypes) {
-      // Get the transport for the client type
-      // There should be a better way to do this
-      const transportMap: { [key: string]: Transport } = {
-        DirectClient: Transport.direct,
-        StdioClient: Transport.stdio,
-        VsockClient: Transport.vsock,
-        TcpClient: Transport.tcp,
-        HttpClient: Transport.http,
-        WebSocketClient: Transport.ws
-      }
-      const transport = transportMap[ClientType.name]
-      if (transport === undefined)
-        throw new InternalError(
-          `Wooah! A key is missing for "${ClientType.name}" in transportMap.`
-        )
-
-      // See if the peer has an address for the transport
-      if (this.manifest.addresses === undefined) return false
-      const address = this.manifest.addresses[transport]
-      if (address !== undefined) {
-        this.interface = new ClientType(address)
-        return true
-      }
-    }
-    // Unable to connect to the peer
-    return false
-  }
-
-  /**
-   * Call a method of a remote `Executor`.
-   *
-   * Ensures that there is a connection to the
-   * executor and then passes the request to it.
-   *
-   * @param method The name of the method
-   * @param params Values of parameters (i.e. arguments)
-   */
-  public async call<Type>(
-    method: Method,
-    params: { [key: string]: any } = {}
-  ): Promise<Type> {
-    if (this.interface === undefined)
-      throw new InternalError(
-        "WTF, no client! You shouldn't be calling this yet!"
-      )
-    return this.interface.call<Type>(method, params)
-  }
-}
-
-/**
- * A base `Executor` class implementation.
- *
- * This executor class has limited capabilities itself and
- * instead, mostly delegates to other executors. If unable
- * to delegate to a peer, then falls back to returning
- * the `Node` unchanged (for `compile`, `build` etc) or
- * attempting to use JSON as format (for `decode` and `encode`).
- */
-export class Executor implements Interface {
-  /**
-   * Functions used to obtain manifests of potential
-   * peer executors.
-   */
-  private readonly discoveryFunctions: DiscoveryFunction[]
-
-  /**
-   * Classes of `Client` that this executor is able
-   * to use to connect to peer executors.
-   */
-  private readonly clientTypes: ClientType[]
-
-  /**
-   * Peer executors that are delegated to depending
-   * upon their capabilities and the request at hand.
-   *
-   * This list is just-in-time populated when a request
-   * is made to the executor that it needs to delegate,
-   * or by explicitly calling `discover()`.
-   */
-  private peers?: Peer[]
-
-  /**
-   * Servers that will pass on requests to this executor.
-   */
-  private readonly servers: Server[] = []
-
-  public constructor(
-    discoveryFunctions: DiscoveryFunction[] = [],
-    clientTypes: ClientType[] = [],
-    servers: Server[] = []
-  ) {
-    this.discoveryFunctions = discoveryFunctions
-    this.clientTypes = clientTypes
-    this.servers = servers
-  }
-
-  /**
-   * Start servers for the executor.
-   */
-  public async start(): Promise<void> {
-    if (this.servers.length === 0) {
-      log.warn('No servers configured; executor will not be accessible.')
-      return
-    }
-
-    log.info(
-      `Starting servers: ${this.servers
-        .map(server => server.address.type)
-        .join(', ')}`
-    )
-    await Promise.all(this.servers.map(server => server.start(this)))
-  }
-
-  /**
-   * Stop servers for the executor.
-   */
-  public async stop(): Promise<void> {
-    log.info('Stopping servers')
-    await Promise.all(this.servers.map(server => server.stop()))
-  }
-
-  /**
-   * Get the manifest of the executor
-   *
-   * Derived classes may override this method,
-   * but will normally just override `capabilities()`.
-   */
-  public async manifest(): Promise<Manifest> {
-    return {
-      capabilities: await this.capabilities(),
-      addresses: this.addresses()
-    }
-  }
-
-  /**
-   * Get the capabilities of the executor
-   *
-   * Derived classes will usually override this method
-   * to declare additional node types that methods such
-   * as `compile` and `execute` can handle.
-   */
-  protected async capabilities(): Promise<Capabilities> {
-    // Define the capabilities that this executor
-    // has without needing to delegate
-    const capabilities: Capabilities = {
-      decode: [
-        // Can decode string content of JSON format
-        {
-          properties: {
-            content: { type: 'string' },
-            format: { const: 'json' }
-          },
-          required: ['content']
-        }
-      ],
-      encode: [
-        // Can encode any node to JSON format
-        {
-          properties: {
-            node: true,
-            format: { const: 'json' }
-          },
-          required: ['node']
-        }
-      ]
-    }
-
-    // Do peer discovery if not yet done
-    if (this.peers === undefined) await this.discover()
-    // This may be able to be removed with assert signatures in TS 3.7
-    if (this.peers === undefined)
-      throw new InternalError(
-        `Whaaaat! How can this be, peers are still undefined!?`
-      )
-
-    // Merge in the capabilities of peer executors
-    for (const peer of this.peers) {
-      const manifest = peer.manifest
-      if (manifest.capabilities === undefined) continue
-      for (const [method, additional] of Object.entries(
-        manifest.capabilities
-      )) {
-        const current = capabilities[method]
-        capabilities[method] = [
-          ...(Array.isArray(current) ? current : [current]),
-          ...(Array.isArray(additional) ? additional : [additional])
-        ]
-      }
-    }
-
-    return capabilities
-  }
-
-  /**
-   * Get a map of server addresses for this executor.
-   */
-  public addresses(): Addresses {
-    return this.servers
-      .map(server => server.address)
-      .reduce((prev, curr) => ({ ...prev, ...{ [curr.type]: curr } }), {})
-  }
-
-  public async decode(content: string, format = 'json'): Promise<Node> {
-    if (format === 'json') return JSON.parse(content)
-    return this.delegate(Method.decode, { content, format }, () =>
-      this.decode(content, 'json')
-    )
-  }
-
-  public async encode(node: Node, format = 'json'): Promise<string> {
-    if (format === 'json') return JSON.stringify(node)
-    return this.delegate(Method.encode, { node, format }, () =>
-      this.encode(node, 'json')
-    )
-  }
-
-  public async compile(node: Node): Promise<Node> {
-    return this.delegate(Method.compile, { node }, () => Promise.resolve(node))
-  }
-
-  public async build(node: Node): Promise<Node> {
-    return this.delegate(Method.build, { node }, () => Promise.resolve(node))
-  }
-
-  /**
-   * Execute a `Node`.
-   *
-   * Walks the node tree and attempts to delegate
-   * execution of certain types of nodes
-   * (currently `CodeChunk` and `CodeExpression`).
-   *
-   * @param node The node to execute
-   * @param session The session to execute the node within
-   */
-  public execute(node: Node, session?: SoftwareSession): Promise<Node> {
-    return this.walk(node, node => {
-      switch (nodeType(node)) {
-        case 'CodeChunk':
-        case 'CodeExpression':
-          return this.delegate(Method.execute, { node, session }, () =>
-            Promise.resolve({
-              ...(node as object),
-              errors: [
-                {
-                  type: 'CodeError',
-                  kind: 'incapable',
-                  message: 'Not able to execute this type of code.'
-                }
-              ]
-            })
-          )
-      }
-      return Promise.resolve(node)
-    })
-  }
-
-  /**
-   * Begin running a `Node`.
-   */
-  public begin(node: Node): Promise<Node> {
-    return this.delegate(Method.begin, { node }, () => Promise.resolve(node))
-  }
-
-  /**
-   * End running a `Node`.
-   */
-  public end(node: Node): Promise<Node> {
-    return this.delegate(Method.end, { node }, () => Promise.resolve(node))
-  }
-
-  public async call(
-    method: Method,
-    params: { [key: string]: any }
-  ): Promise<any> {
-    switch (method) {
-      case Method.decode:
-        return this.decode(params.content, params.format)
-      case Method.encode:
-        return this.encode(params.node, params.format)
-      case Method.compile:
-        return this.compile(params.node)
-      case Method.build:
-        return this.build(params.node)
-      case Method.execute:
-        return this.execute(params.node, params.session)
-    }
-  }
-
-  private async walk(
-    root: Node,
-    transformer: (node: Node) => Promise<Node>
-  ): Promise<Node> {
-    return walk(root)
-    async function walk(node: Node): Promise<Node> {
-      const transformed = await transformer(node)
-
-      if (transformed !== node) return transformed
-
-      if (transformed === undefined || isPrimitive(transformed))
-        return transformed
-      if (Array.isArray(transformed)) return Promise.all(transformed.map(walk))
-      return Object.entries(transformed).reduce(
-        async (prev, [key, child]) => ({
-          ...(await prev),
-          ...{ [key]: await walk(child) }
-        }),
-        Promise.resolve({})
-      )
-    }
-  }
-
-  /**
-   * Discover peers by calling discovery functions.
-   *
-   * This gets called just-in-time, but you may also want to
-   * call it ahead-of-time to reduce latency
-   * in the first method call.
-   */
-  private async discover(): Promise<void> {
-    log.info(`Discovering peers`)
-
-    // Get the list of manifests
-    const manifests = await this.discoveryFunctions.reduce(
-      async (all: Promise<Manifest[]>, discoveryFunction) => {
-        return [...(await all), ...(await discoveryFunction())]
-      },
-      Promise.resolve([])
-    )
-
-    if (manifests.length === 0) {
-      log.warn(
-        'No peer executors discovered. Executor will have limited capabilities.'
-      )
-    }
-
-    // Create a list of peers
-    this.peers = manifests.map(manifest => new Peer(manifest, this.clientTypes))
-  }
-
-  /**
-   * Delegate a method call to a peer.
-   *
-   * @param method The method name
-   * @param params The parameter values (i.e. the arguments)
-   * @param fallback A fallback function called if unable to delegate
-   */
-  private async delegate<Type>(
-    method: Method,
-    params: { [key: string]: any },
-    fallback: () => Promise<Type>
-  ): Promise<Type> {
-    log.debug(`Delegating: ${method}(${Object.keys(params).join(', ')})`)
-
-    // Do peer discovery if not yet done
-    if (this.peers === undefined) await this.discover()
-    // This may be able to be removed with assert signatures in TS 3.7
-    if (this.peers === undefined)
-      throw new InternalError(
-        `Whaaaat! How can this be, peers are still undefined!?`
-      )
-
-    // Attempt to delegate to a peer
-    for (const peer of this.peers) {
-      if (peer.capable(method, params)) {
-        if (peer.connect()) {
-          return peer.call<Type>(method, params)
-        }
-      }
-    }
-
-    // No peer has necessary capability so resort to fallback
-    log.debug(`Unable to delegate node: ${JSON.stringify(params)} `)
-    return fallback()
-  }
 }

--- a/src/base/Server.ts
+++ b/src/base/Server.ts
@@ -4,6 +4,7 @@ import { JsonRpcError, JsonRpcErrorCode } from './JsonRpcError'
 import { JsonRpcRequest } from './JsonRpcRequest'
 import { JsonRpcResponse } from './JsonRpcResponse'
 import { Address } from './Transports'
+import { BaseExecutor } from './BaseExecutor'
 
 /**
  * A base server class that passes JSON-RPC requests
@@ -112,9 +113,14 @@ export abstract class Server {
             param(request, 1, 'session', false)
           )
           break
+        case 'begin':
+          result = await this.executor[request.method](
+            param(request, 0, 'node'),
+            param(request, 1, 'limits', false)
+          )
+          break
         case 'compile':
         case 'build':
-        case 'begin':
         case 'end':
           result = await this.executor[request.method](
             param(request, 0, 'node')
@@ -150,7 +156,7 @@ export abstract class Server {
    * call this method, or ensure that `executor` is set themselves.
    */
   public start(executor?: Executor): Promise<void> {
-    if (executor === undefined) executor = new Executor()
+    if (executor === undefined) executor = new BaseExecutor()
     this.executor = executor
     return Promise.resolve()
   }

--- a/src/base/Server.ts
+++ b/src/base/Server.ts
@@ -25,11 +25,14 @@ export abstract class Server {
    * Handle a request
    *
    * @param request A JSON-RPC request from a client
+   * @param user An object representing the user and their rights,
+   *             usually a JWT payload
    * @param stringify Should the response be stringified?
    * @returns A JSON-RPC response as an object or string (default)
    */
   protected async receive(
     request: string | JsonRpcRequest,
+    user: any = {},
     stringify = true
   ): Promise<string | JsonRpcResponse> {
     if (this.executor === undefined)
@@ -116,7 +119,9 @@ export abstract class Server {
         case 'begin':
           result = await this.executor[request.method](
             param(request, 0, 'node'),
-            param(request, 1, 'limits', false)
+            // Any `limits` parameter requested are ignored and instead
+            // the session limits from the user token are applied
+            user.session !== undefined ? user.session : {}
           )
           break
         case 'compile':

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -19,14 +19,10 @@
  */
 
 import { ClientType } from './base/Client'
-import { Executor } from './base/Executor'
+import { BaseExecutor } from './base/BaseExecutor'
 import { discover as discoverHttp } from './http/discover'
 import { HttpClient } from './http/HttpClient'
 import { WebSocketClient } from './ws/WebSocketClient'
-
-const red = '\u001b[31;1m'
-const blue = '\u001b[34;1m'
-const reset = '\u001b[0m'
 
 // @ts-ignore
 window.process = {
@@ -37,12 +33,12 @@ window.process = {
 // eslint-disable-next-line
 ;(async () => {
   // Create executor (no need to start it, since it has no servers)
-  const executor = new Executor(
+  const executor = new BaseExecutor(
     [discoverHttp],
     [HttpClient as ClientType, WebSocketClient as ClientType]
   )
 
-  const makeCodeChunk = async (text: string): Promise<string> =>
+  const makeCodeChunk = (text: string): Promise<string> =>
     executor.encode({
       type: 'CodeChunk',
       programmingLanguage: 'python',

--- a/src/browser/init.ts
+++ b/src/browser/init.ts
@@ -1,26 +1,28 @@
 import '@stencila/components'
 import {
   codeChunk,
-  environment,
   Node,
+  softwareEnvironment,
   softwareSession,
   SoftwareSession
 } from '@stencila/schema'
 import { ClientType } from '../base/Client'
-import { Executor } from '../base/Executor'
+import { BaseExecutor } from '../base/BaseExecutor'
 import { HttpAddress } from '../base/Transports'
 import { discover } from '../http/discover'
 import { HttpClient } from '../http/HttpClient'
 import { WebSocketClient } from '../ws/WebSocketClient'
 
-let executor: Executor
+let executor: BaseExecutor
 let sessionRef: null | SoftwareSession = null
 
 const executeCodeChunk = async (text: string): Promise<Node> => {
   const code = codeChunk(text, { programmingLanguage: 'python' })
 
   if (sessionRef === null) {
-    const session = softwareSession(environment('stencila/sparkla-ubuntu'))
+    const session = softwareSession(
+      softwareEnvironment('stencila/sparkla-ubuntu')
+    )
     sessionRef = await executor.begin(session)
   }
 
@@ -47,7 +49,7 @@ const onReadyHandler = (): void => {
 export const init = (options: Partial<InitOptions> = defaultOptions): void => {
   const { host, path, port } = { ...defaultOptions, ...options }
 
-  executor = new Executor(
+  executor = new BaseExecutor(
     [() => discover(new HttpAddress({ host, port }, path))],
     [HttpClient as ClientType, WebSocketClient as ClientType]
   )

--- a/src/browser/init.ts
+++ b/src/browser/init.ts
@@ -21,7 +21,7 @@ const executeCodeChunk = async (text: string): Promise<Node> => {
 
   if (sessionRef === null) {
     const session = softwareSession(environment('stencila/sparkla-ubuntu'))
-    sessionRef = (await executor.begin(session)) as SoftwareSession
+    sessionRef = await executor.begin(session)
   }
 
   return executor.execute(code, sessionRef)

--- a/src/browser/init.ts
+++ b/src/browser/init.ts
@@ -14,19 +14,16 @@ import { HttpClient } from '../http/HttpClient'
 import { WebSocketClient } from '../ws/WebSocketClient'
 
 let executor: BaseExecutor
-let sessionRef: null | SoftwareSession = null
+let session: null | SoftwareSession = null
 
 const executeCodeChunk = async (text: string): Promise<Node> => {
   const code = codeChunk(text, { programmingLanguage: 'python' })
 
-  if (sessionRef === null) {
-    const session = softwareSession(
-      softwareEnvironment('stencila/sparkla-ubuntu')
-    )
-    sessionRef = await executor.begin(session)
+  if (session === null) {
+    session = await executor.begin(softwareSession())
   }
 
-  return executor.execute(code, sessionRef)
+  return executor.execute(code, session)
 }
 
 const executeHandler = (text: string): Promise<void> =>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,22 +7,22 @@ import {
   replaceHandlers
 } from '@stencila/logga'
 import minimist from 'minimist'
+import { BaseExecutor } from './base/BaseExecutor'
 import { ClientType } from './base/Client'
-import { Executor } from './base/Executor'
 import { Server } from './base/Server'
-import { discover as discoverStdio } from './stdio/discover'
-import { StdioClient } from './stdio/StdioClient'
-import { HttpServer } from './http/HttpServer'
-import { TcpServer } from './tcp/TcpServer'
-import { WebSocketServer } from './ws/WebSocketServer'
 import {
   HttpAddress,
   TcpAddress,
-  WebSocketAddress,
-  VsockAddress
+  VsockAddress,
+  WebSocketAddress
 } from './base/Transports'
-import { VsockServer } from './vsock/VsockServer'
+import { HttpServer } from './http/HttpServer'
+import { discover as discoverStdio } from './stdio/discover'
+import { StdioClient } from './stdio/StdioClient'
 import { StdioServer } from './stdio/StdioServer'
+import { TcpServer } from './tcp/TcpServer'
+import { VsockServer } from './vsock/VsockServer'
+import { WebSocketServer } from './ws/WebSocketServer'
 
 const { _: args, ...options } = minimist(process.argv.slice(2))
 
@@ -79,7 +79,7 @@ const main = async () => {
     )
   }
 
-  const executor = new Executor(
+  const executor = new BaseExecutor(
     [discoverStdio],
     [StdioClient as ClientType],
     servers
@@ -97,14 +97,14 @@ const main = async () => {
 /**
  * Serve the executor
  */
-const serve = async (executor: Executor) => {
+const serve = async (executor: BaseExecutor) => {
   await executor.start()
 }
 
 /**
  * Convert a document
  */
-const convert = async (executor: Executor): Promise<void> => {
+const convert = async (executor: BaseExecutor): Promise<void> => {
   const input = args[1]
   const output = args[2] !== undefined ? args[2] : '-'
 
@@ -115,7 +115,7 @@ const convert = async (executor: Executor): Promise<void> => {
 /**
  * Execute a document
  */
-const execute = async (executor: Executor): Promise<void> => {
+const execute = async (executor: BaseExecutor): Promise<void> => {
   const input = args[1]
   const output = args[2] !== undefined ? args[2] : input
 

--- a/src/console.ts
+++ b/src/console.ts
@@ -28,7 +28,7 @@ import { CodeChunk } from '@stencila/schema'
 import minimist from 'minimist'
 import * as readline from 'readline'
 import { ClientType } from './base/Client'
-import { Executor } from './base/Executor'
+import { BaseExecutor } from './base/BaseExecutor'
 import { discover as discoverTcp } from './tcp/discover'
 import { TcpClient } from './tcp/TcpClient'
 
@@ -55,7 +55,7 @@ replaceHandlers(data => {
 // eslint-disable-next-line
 ;(async () => {
   // Create executor (no need to start it, since it has no servers)
-  const executor = new Executor([discoverTcp], [TcpClient as ClientType])
+  const executor = new BaseExecutor([discoverTcp], [TcpClient as ClientType])
 
   // Create the REPL with the starting prompt
   const repl = readline.createInterface({

--- a/src/direct/DirectClientServer.test.ts
+++ b/src/direct/DirectClientServer.test.ts
@@ -1,11 +1,11 @@
 import * as stencila from '@stencila/schema'
 import { DirectClient } from './DirectClient'
 import { DirectServer } from './DirectServer'
-import { Executor } from '../base/Executor'
+import { BaseExecutor } from '../base/BaseExecutor'
 
 test('DirectClient and DirectServer', async () => {
   const server = new DirectServer()
-  const executor = new Executor()
+  const executor = new BaseExecutor()
   await server.start(executor)
   const client = new DirectClient(server.address)
 

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -4,6 +4,9 @@ import { JsonRpcError } from '../base/JsonRpcError'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 import { JsonRpcResponse } from '../base/JsonRpcResponse'
 import { HttpAddress } from '../base/Transports'
+import { getLogger } from '@stencila/logga';
+
+const log = getLogger('executa:http:client')
 
 /**
  * A `Client` using HTTP/S for communication.
@@ -48,7 +51,7 @@ export class HttpClient extends Client {
       .then((response: JsonRpcResponse) => {
         this.receive(response)
       })
-      .catch(err => console.error(err))
+      .catch(err => log.error(err))
   }
 
   // Additional methods for getting and posting to server

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -4,7 +4,7 @@ import { JsonRpcError } from '../base/JsonRpcError'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 import { JsonRpcResponse } from '../base/JsonRpcResponse'
 import { HttpAddress } from '../base/Transports'
-import { getLogger } from '@stencila/logga';
+import { getLogger } from '@stencila/logga'
 
 const log = getLogger('executa:http:client')
 

--- a/src/http/HttpClientServer.test.ts
+++ b/src/http/HttpClientServer.test.ts
@@ -9,7 +9,10 @@ beforeAll(() => {
 test('HttpClient and HttpServer', async () => {
   const server = new HttpServer()
   await server.start()
+
   const client = new HttpClient(server.address)
   await testClient(client)
+  await client.stop()
+
   await server.stop()
 })

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -4,6 +4,7 @@ import fastifyCors from 'fastify-cors'
 import fastifyJwt from 'fastify-jwt'
 import jwt from 'jsonwebtoken'
 import { Executor } from '../base/Executor'
+import { BaseExecutor } from '../base/BaseExecutor'
 import { InternalError } from '../base/InternalError'
 import { JsonRpcErrorCode } from '../base/JsonRpcError'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
@@ -113,7 +114,7 @@ export class HttpServer extends TcpServer {
   }
 
   public async start(executor?: Executor): Promise<void> {
-    if (executor === undefined) executor = new Executor()
+    if (executor === undefined) executor = new BaseExecutor()
     this.executor = executor
 
     const url = this.address.toString()

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,4 +1,4 @@
-export { Executor } from './base/Executor'
+export { BaseExecutor } from './base/BaseExecutor'
 export { init } from './browser/init'
 export { discover as discoverHttp } from './http/discover'
 export { HttpClient } from './http/HttpClient'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 export { Executor } from './base/Executor'
+export { BaseExecutor } from './base/BaseExecutor'
+
+export { StreamClient } from './stream/StreamClient'
+export { StreamServer } from './stream/StreamServer'
 
 export { StdioAddress } from './base/Transports'
 export { discover as stdioDiscover } from './stdio/discover'

--- a/src/stdio/StdioClient.ts
+++ b/src/stdio/StdioClient.ts
@@ -39,9 +39,10 @@ export class StdioClient extends StreamClient {
   /**
    * Stop the child server process
    */
-  stop() {
+  public stop(): Promise<void> {
     // Avoid unnecessary log errors by removing listener
     this.child.removeAllListeners('exit')
     this.child.kill()
+    return Promise.resolve()
   }
 }

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -5,12 +5,12 @@ import { testClient } from '../test/testClient'
 jest.setTimeout(30 * 1000)
 
 describe('StdioClient and StdioServer', () => {
-  const testServer = (arg = '') =>
+  const testServer = (arg = ''): string =>
     `npx ts-node ${path.join(__dirname, 'stdioTestServer.ts')} ${arg}`
 
   test('all-is-ok', async () => {
     const client = new StdioClient(testServer())
     await testClient(client)
-    client.stop()
+    await client.stop()
   })
 })

--- a/src/stdio/dockerServer.e2e.ts
+++ b/src/stdio/dockerServer.e2e.ts
@@ -8,5 +8,5 @@ test('run a StdioServer inside a Docker container', async () => {
   // Also means that the container stops when the client is stopped.
   const client = new StdioClient(`docker run --interactive stencila/executa`)
   await testClient(client)
-  client.stop()
+  await client.stop()
 })

--- a/src/stream/StreamClient.ts
+++ b/src/stream/StreamClient.ts
@@ -4,20 +4,24 @@ import * as lps from 'length-prefixed-stream'
 import { Client } from '../base/Client'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 
-export abstract class StreamClient extends Client {
+export class StreamClient extends Client {
   /**
    * Encoder to send length prefixed messages over outgoing stream.
    */
   private encoder: lps.Encoder
 
   /**
-   * Create an instance of StreamClient.
+   * Create an instance of `StreamClient`.
    *
    * @param {Writable} outgoing Outgoing stream to send JSON-RPC requests on.
    * @param {Readable} incoming Incoming stream to receive JSON-RPC responses on.
    */
   public constructor(outgoing: Writable, incoming: Readable) {
     super()
+
+    // Do not keep reference to streams since they
+    // are provided to this constructor, so probably
+    // don't want to destroy them in this class
 
     this.encoder = lps.encode()
     this.encoder.pipe(outgoing)

--- a/src/stream/StreamClientServer.test.ts
+++ b/src/stream/StreamClientServer.test.ts
@@ -12,7 +12,6 @@ describe('StreamClient and StreamServer', () => {
   const serverOutgoing = new PassThrough()
   server.start(executor, serverIncoming, serverOutgoing)
 
-  // @ts-ignore Ignore the fact that this is an abstract class
   const client = new StreamClient(serverIncoming, serverOutgoing)
 
   test('calling manifest', async () => {

--- a/src/stream/StreamClientServer.test.ts
+++ b/src/stream/StreamClientServer.test.ts
@@ -2,12 +2,12 @@ import { PassThrough } from 'stream'
 import * as stencila from '@stencila/schema'
 import { StreamClient } from './StreamClient'
 import { StreamServer } from './StreamServer'
-import { Executor } from '../base/Executor'
+import { BaseExecutor } from '../base/BaseExecutor'
 
 describe('StreamClient and StreamServer', () => {
   // @ts-ignore Ignore the fact that this is an abstract class
   const server = new StreamServer()
-  const executor = new Executor()
+  const executor = new BaseExecutor()
   const serverIncoming = new PassThrough()
   const serverOutgoing = new PassThrough()
   server.start(executor, serverIncoming, serverOutgoing)

--- a/src/tcp/TcpClient.ts
+++ b/src/tcp/TcpClient.ts
@@ -22,7 +22,8 @@ export class TcpClient extends StreamClient {
     this.socket = socket
   }
 
-  public stop() {
+  public stop(): Promise<void> {
     this.socket.destroy()
+    return Promise.resolve()
   }
 }

--- a/src/tcp/TcpClientServer.test.ts
+++ b/src/tcp/TcpClientServer.test.ts
@@ -5,7 +5,10 @@ import { testClient } from '../test/testClient'
 test('TcpClient and TcpServer', async () => {
   const server = new TcpServer()
   await server.start()
+
   const client = new TcpClient(server.address)
   await testClient(client)
+  await client.stop()
+
   await server.stop()
 })

--- a/src/tcp/discover.ts
+++ b/src/tcp/discover.ts
@@ -11,6 +11,6 @@ import { TcpClient } from './TcpClient'
 export async function discover(address?: TcpAddress): Promise<Manifest[]> {
   const client = new TcpClient(address)
   const manifest = await client.manifest()
-  client.stop()
+  await client.stop()
   return [manifest]
 }

--- a/src/test/EchoExecutor.ts
+++ b/src/test/EchoExecutor.ts
@@ -1,0 +1,17 @@
+import { BaseExecutor } from '../base/BaseExecutor'
+import { Node, SoftwareSession } from '@stencila/schema'
+
+/**
+ * A test `Executor` which echos back the arguments
+ * it received as a new object. Used for testing that
+ * `Server` implementations pass through arguments correctly.
+ */
+export class EchoExecutor extends BaseExecutor {
+  begin<NodeType extends Node>(
+    node: NodeType,
+    limits?: SoftwareSession
+  ): Promise<NodeType> {
+    // This intentionally breaks contract to return the same node type as received
+    return Promise.resolve(({ node, limits } as unknown) as NodeType)
+  }
+}

--- a/src/test/testClient.ts
+++ b/src/test/testClient.ts
@@ -24,7 +24,7 @@ export const testClient = async (client: Client): Promise<void> => {
       { type: 'Entity' },
       {
         type: 'SoftwareSession',
-        environment: { type: 'Environment', name: 'anything' }
+        environment: { type: 'SoftwareEnvironment', name: 'anything' }
       }
     )
   ).toEqual({ type: 'Entity' })

--- a/src/test/testClient.ts
+++ b/src/test/testClient.ts
@@ -7,7 +7,7 @@ import { Client } from '../base/Client'
  *
  * @param client An instance of a `Client`
  */
-export const testClient = async (client: Client) => {
+export const testClient = async (client: Client): Promise<void> => {
   expect(await client.decode('3.14')).toEqual(3.14)
   expect(await client.decode('{"type":"Entity"}', 'json')).toEqual({
     type: 'Entity'

--- a/src/vsock/VsockFirecrackerClient.ts
+++ b/src/vsock/VsockFirecrackerClient.ts
@@ -30,7 +30,8 @@ export class VsockFirecrackerClient extends StreamClient {
     this.socket = socket
   }
 
-  public stop(): void {
+  public stop(): Promise<void> {
     this.socket.destroy()
+    return Promise.resolve()
   }
 }

--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -33,7 +33,8 @@ export class WebSocketClient extends Client {
     this.socket.send(JSON.stringify(request))
   }
 
-  public stop() {
+  public stop(): Promise<void> {
     this.socket.close()
+    return Promise.resolve()
   }
 }

--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -3,6 +3,9 @@ import WebSocket from 'isomorphic-ws'
 import { Client } from '../base/Client'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 import { WebSocketAddress } from '../base/Transports'
+import { getLogger } from '@stencila/logga'
+
+const log = getLogger('executa:ws:client')
 
 /**
  * A `Client` using the WebSockets API for communication.
@@ -18,7 +21,10 @@ export class WebSocketClient extends Client {
 
     const { host = '127.0.1.1', port = '9000', path = '', jwt } = address
     const url = `ws://${host}:${port}${path}`
-    this.socket = new WebSocket(url, jwt)
+    const socket = (this.socket = new WebSocket(url, jwt))
+
+    socket.on('error', error => log.error(error))
+
     this.socket.addEventListener('message', event => {
       this.receive(event.data)
     })
@@ -30,7 +36,10 @@ export class WebSocketClient extends Client {
         this.socket.onopen = () => resolve()
       })
     }
-    this.socket.send(JSON.stringify(request))
+    const json = JSON.stringify(request)
+    this.socket.send(json, error => {
+      if (error !== undefined) log.error(error)
+    })
   }
 
   public stop(): Promise<void> {

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -1,18 +1,74 @@
 import { testClient } from '../test/testClient'
 import { WebSocketClient } from './WebSocketClient'
 import { WebSocketServer } from './WebSocketServer'
+import { addHandler, LogData } from '@stencila/logga'
+import JWT from 'jsonwebtoken'
+import { EchoExecutor } from '../test/EchoExecutor'
+import { softwareSession, softwareEnvironment } from '@stencila/schema'
+
+const JWT_SECRET = 'not-a-secret-at-all'
 
 beforeAll(() => {
-  process.env.JWT_SECRET = 'not-a-secret-at-all'
+  process.env.JWT_SECRET = JWT_SECRET
 })
 
 test('WebSocketClient and WebSocketServer', async () => {
-  const server = new WebSocketServer()
-  await server.start()
+  let clientLog: LogData = { tag: '', level: 0, message: '' }
+  addHandler((logData: LogData) => {
+    if (logData.tag === 'executa:ws:client') {
+      clientLog = logData
+    }
+  })
 
-  const client = new WebSocketClient(server.address)
-  await testClient(client)
-  await client.stop()
+  const server = new WebSocketServer()
+  const executor = new EchoExecutor()
+  await server.start(executor)
+
+  {
+    // Well behaved client
+    const client = new WebSocketClient(server.address)
+    await testClient(client)
+    await client.stop()
+  }
+
+  {
+    // JWT with session limits to be used for begin() method
+    const sessionRequests = softwareSession(
+      softwareEnvironment('some-eviron'),
+      {
+        cpuRequested: 4,
+        memoryRequested: 5
+      }
+    )
+    const sessionLimits = softwareSession(softwareEnvironment('some-eviron'), {
+      cpuLimit: 2,
+      memoryLimit: 2
+    })
+    const jwt = JWT.sign({ session: sessionLimits }, JWT_SECRET)
+    const client = new WebSocketClient({ ...server.address, jwt })
+    const echoed = await client.begin(sessionRequests)
+    expect(echoed).toEqual({
+      node: sessionRequests,
+      limits: sessionLimits
+    })
+  }
+
+  {
+    // Client with malformed JWT
+    const _ = new WebSocketClient({ ...server.address, jwt: 'jwhaaaat?' })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(clientLog.message).toMatch(/Unexpected server response: 401/)
+  }
+
+  {
+    // Client with invalid JWT
+    const _ = new WebSocketClient({
+      ...server.address,
+      jwt: JWT.sign({}, 'not-the-right-secret')
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    expect(clientLog.message).toMatch(/Unexpected server response: 401/)
+  }
 
   await server.stop()
 })

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -33,14 +33,13 @@ test('WebSocketClient and WebSocketServer', async () => {
 
   {
     // JWT with session limits to be used for begin() method
-    const sessionRequests = softwareSession(
-      softwareEnvironment('some-eviron'),
-      {
-        cpuRequested: 4,
-        memoryRequested: 5
-      }
-    )
-    const sessionLimits = softwareSession(softwareEnvironment('some-eviron'), {
+    const sessionRequests = softwareSession({
+      environment: softwareEnvironment('some-eviron'),
+      cpuRequested: 4,
+      memoryRequested: 5
+    })
+    const sessionLimits = softwareSession({
+      environment: softwareEnvironment('some-eviron'),
       cpuLimit: 2,
       memoryLimit: 2
     })

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -19,7 +19,7 @@ export class WebSocketServer extends HttpServer {
     const secret = process.env.JWT_SECRET
     if (secret === undefined)
       throw new InternalError('Environment variable JWT_SECRET must be set')
-    const authorize = (info: any, next: (ok: boolean) => void) => {
+    const authorize = (info: any, next: (ok: boolean) => void): void => {
       const token = info.req.headers['sec-websocket-protocol']
       if (token !== undefined) {
         try {

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken'
 import { InternalError } from '../base/InternalError'
 import { WebSocketAddress } from '../base/Transports'
 import { HttpServer } from '../http/HttpServer'
+import { Socket } from 'net'
 
 const log = getLogger('executa:ws:server')
 
@@ -12,35 +13,58 @@ const log = getLogger('executa:ws:server')
  * A `Server` using WebSockets for communication.
  */
 export class WebSocketServer extends HttpServer {
+  /**
+   * A map of JWT tokens to their payload.
+   *
+   * This is necessary, because we need to keep provide the
+   * JWT payload to `this.executor` on each message.
+   * In `HttpServer` this is easy because the payload is
+   * attached to the request as the `user` property.
+   * Here, we need to do the association ourselves.
+   */
+  users: { [key: string]: any } = {}
+
   public constructor(address: WebSocketAddress = new WebSocketAddress()) {
     super(address)
 
-    // Apply JWT-based authorization of each connection
+    // Verify the JWT for each connection and store
+    // it's payload so it can be used against each
+    // subsequent request message.
     const secret = process.env.JWT_SECRET
     if (secret === undefined)
       throw new InternalError('Environment variable JWT_SECRET must be set')
     const authorize = (info: any, next: (ok: boolean) => void): void => {
-      const token = info.req.headers['sec-websocket-protocol']
-      if (token !== undefined) {
-        try {
-          jwt.verify(token, secret)
-          next(true)
-        } catch {
-          next(false)
-        }
-      } else next(false)
+      const { headers } = info.req
+      const token = headers['sec-websocket-protocol']
+      if (token === undefined) return next(false)
+      try {
+        this.users[token] = jwt.verify(token, secret)
+        next(true)
+      } catch {
+        next(false)
+      }
     }
 
     this.app.register(fastifyWebsocket, {
       handle: (connection: any) => {
         const { socket } = connection
-        // Handle messages from connection
-        socket.on('message', async (message: string) => {
-          socket.send(await this.receive(message))
-        })
+
+        const token = socket.protocol
+        const user = this.users[token]
+        if (user === undefined) {
+          // This should not happen
+          log.error('Unable to get user for connection')
+        }
+
         // Register connection and disconnection handler
         this.onConnected(connection)
-        socket.on('close', () => this.onDisconnected(connection))
+        socket.on('close', () => this.onDisconnected(connection, token))
+
+        // Handle messages from connection
+        socket.on('message', async (message: string) => {
+          const response = await this.receive(message, user)
+          socket.send(response)
+        })
       },
       options: {
         verifyClient: authorize
@@ -57,5 +81,16 @@ export class WebSocketServer extends HttpServer {
       '',
       this.defaultJwt
     )
+  }
+
+  /**
+   * When a client disconnects, remove it's payload
+   * from `this.users`.
+   *
+   * @param client The client socket
+   * @param token The JWT token
+   */
+  protected onDisconnected(client: Socket, token?: string) {
+    if (token !== undefined) delete this.users[token]
   }
 }


### PR DESCRIPTION
Various related changes:
- rename `Interface` to `Executor` (the `interface`) and `Executor` to `BaseExecutor` (a base `class` that `implements Executor` and can be extended).
- node return type is same as node arg type e.g.
```ts
abstract async execute<NodeType extends Node>(
    node: NodeType,
    session?: SoftwareSession
): Promise<NodeType>
```
- `begin` method: add a `limits` parameter (for issue https://github.com/stencila/sparkla/issues/13)
- `HttpServer` and WebSocketServer` pass JWT payload `session` to `executor.begin` as `limits`