### PR TITLE
feat(Addresses): Allow for addresses to be initialised in various ways

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="dist/browser/index.js"></script>
     <script>
-      window.Stencila.executa.init()
+      window.Stencila.executa.init({
+        host: window.location.hostname,
+        port: 9000
+      })
     </script>
     <script
       type="module"

--- a/src/base/BaseExecutor.test.ts
+++ b/src/base/BaseExecutor.test.ts
@@ -181,7 +181,6 @@ describe('Peer', () => {
         capabilities: {},
         addresses: {
           http: {
-            type: Transport.http,
             host: '127.0.0.1',
             port: 8000
           }
@@ -202,10 +201,7 @@ describe('Peer', () => {
           type: Transport.direct,
           server: directServer
         },
-        stdio: {
-          type: Transport.stdio,
-          command: 'echo'
-        }
+        stdio: 'echo'
       }
     }
     const peer1 = new Peer(manifest, [

--- a/src/base/Executor.ts
+++ b/src/base/Executor.ts
@@ -1,6 +1,15 @@
-import { JSONSchema7Definition } from 'json-schema'
-import { Address, Transport } from './Transports'
 import { Node, SoftwareSession } from '@stencila/schema'
+import { JSONSchema7Definition } from 'json-schema'
+import {
+  DirectAddress,
+  HttpAddressInitializer,
+  StdioAddressInitializer,
+  TcpAddressInitializer,
+  Transport,
+  UdsAddress,
+  VsockAddress,
+  WebSocketAddressInitializer
+} from './Transports'
 
 /**
  * The methods of an `Executor` class.
@@ -33,7 +42,13 @@ export interface Capabilities {
  * The addresses of an `Executor`.
  */
 export interface Addresses {
-  [key: string]: Address
+  direct?: DirectAddress
+  stdio?: StdioAddressInitializer
+  uds?: UdsAddress
+  vsock?: VsockAddress
+  tcp?: TcpAddressInitializer
+  http?: HttpAddressInitializer
+  ws?: WebSocketAddressInitializer
 }
 
 /**

--- a/src/base/Transports.test.ts
+++ b/src/base/Transports.test.ts
@@ -1,57 +1,173 @@
-import { TcpAddress, HttpAddress } from './Transports'
+import { TcpAddress, HttpAddress, WebSocketAddress } from './Transports'
 
 describe('TcpAddress', () => {
   const defaults = {
+    type: 'tcp',
+    scheme: 'tcp',
     host: '127.0.0.1',
-    port: 4321
+    port: 7000
   }
 
-  test('constructor: string with host and port', () => {
-    expect(new TcpAddress('example.com:2010', defaults)).toEqual({
-      type: 'tcp',
-      host: 'example.com',
-      port: 2010
-    })
+  test('constructor: default', () => {
+    expect(new TcpAddress()).toEqual(defaults)
+  })
+
+  test('constructor: string as the port', () => {
+    expect(new TcpAddress('2010')).toEqual({ ...defaults, port: 2010 })
   })
 
   test('constructor: number as the port', () => {
-    expect(new TcpAddress(2020, defaults)).toEqual({
-      type: 'tcp',
-      host: '127.0.0.1',
+    expect(new TcpAddress(2020)).toEqual({ ...defaults, port: 2020 })
+  })
+
+  test('constructor: string with just host', () => {
+    expect(new TcpAddress('example.com')).toEqual({
+      ...defaults,
+      host: 'example.com'
+    })
+  })
+
+  test('constructor: string with host and port', () => {
+    expect(new TcpAddress('example.com:2020')).toEqual({
+      ...defaults,
+      host: 'example.com',
       port: 2020
     })
   })
 
-  test('constructor: string with just port', () => {
-    expect(new TcpAddress('2030', defaults)).toEqual({
-      type: 'tcp',
-      host: '127.0.0.1',
-      port: 2030
+  test('constructor: string with scheme, host and port', () => {
+    expect(new TcpAddress('tcp://example.com:2020')).toEqual({
+      ...defaults,
+      host: 'example.com',
+      port: 2020
     })
   })
 
   test('toString', () => {
-    expect(new TcpAddress().toString()).toEqual('tcp://127.0.0.1:7000')
+    expect(new TcpAddress().url()).toEqual('tcp://127.0.0.1:7000')
   })
 })
 
 describe('HttpAddress', () => {
-  test('constructor: string with host and port', () => {
-    expect(new HttpAddress()).toEqual({
-      type: 'http',
-      host: '127.0.0.1',
+  const defaults = {
+    type: 'http',
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: 80
+  }
+
+  test('constructor: defaults', () => {
+    expect(new HttpAddress()).toEqual(defaults)
+  })
+
+  test('constructor: port is scheme default', () => {
+    expect(new HttpAddress('https://127.0.0.1')).toEqual({
+      ...defaults,
+      scheme: 'https',
+      port: 443
+    })
+  })
+
+  test('constructor: string with scheme and path', () => {
+    expect(new HttpAddress('https://server1.example.com/a-path')).toEqual({
+      ...defaults,
+      scheme: 'https',
+      host: 'server1.example.com',
+      port: 443,
+      path: 'a-path'
+    })
+  })
+
+  test('constructor: string with scheme, port and path', () => {
+    expect(
+      new HttpAddress('https://server1.example.com:8000/path/2/a/place')
+    ).toEqual({
+      ...defaults,
+      scheme: 'https',
+      host: 'server1.example.com',
       port: 8000,
-      path: '',
-      protocol: 'jsonrpc',
-      jwt: undefined
+      path: 'path/2/a/place'
+    })
+  })
+
+  test('constructor: object with scheme, port and path', () => {
+    expect(
+      new HttpAddress({
+        scheme: 'https',
+        port: 8991,
+        path: 'custom/path'
+      })
+    ).toEqual({
+      ...defaults,
+      scheme: 'https',
+      port: 8991,
+      path: 'custom/path'
     })
   })
 
   test('toString', () => {
-    expect(new HttpAddress().toString()).toEqual('http://127.0.0.1:8000')
+    expect(new HttpAddress(8080).url()).toEqual('http://127.0.0.1:8080')
 
-    expect(new HttpAddress(undefined, '/some/path').toString()).toEqual(
-      'http://127.0.0.1:8000/some/path'
+    expect(
+      new HttpAddress({ host: 'example.org', path: 'some/path' }).url()
+    ).toEqual('http://example.org/some/path')
+
+    expect(new HttpAddress('https://example.org').url()).toEqual(
+      'https://example.org'
+    )
+
+    expect(new HttpAddress('https://example.org:4444').url()).toEqual(
+      'https://example.org:4444'
+    )
+  })
+})
+
+describe('WebSocketAddress', () => {
+  const defaults = {
+    type: 'ws',
+    scheme: 'ws',
+    host: '127.0.0.1',
+    port: 80
+  }
+
+  test('constructor: defaults', () => {
+    expect(new WebSocketAddress()).toEqual(defaults)
+  })
+
+  test('constructor: string with scheme, port and path', () => {
+    expect(
+      new WebSocketAddress('wss://server1.example.com:8000/path/2/a/place')
+    ).toEqual({
+      ...defaults,
+      scheme: 'wss',
+      host: 'server1.example.com',
+      port: 8000,
+      path: 'path/2/a/place'
+    })
+  })
+
+  test('constructor: object with scheme, port and path', () => {
+    expect(
+      new WebSocketAddress({
+        scheme: 'wss',
+        port: 8991,
+        path: 'custom/path'
+      })
+    ).toEqual({
+      ...defaults,
+      scheme: 'wss',
+      port: 8991,
+      path: 'custom/path'
+    })
+  })
+
+  test('toString', () => {
+    expect(new WebSocketAddress('ws://example.org').url()).toEqual(
+      'ws://example.org'
+    )
+
+    expect(new WebSocketAddress('wss://example.org:4444').url()).toEqual(
+      'wss://example.org:4444'
     )
   })
 })

--- a/src/browser/init.ts
+++ b/src/browser/init.ts
@@ -2,11 +2,11 @@ import '@stencila/components'
 import { CodeChunk, softwareSession, SoftwareSession } from '@stencila/schema'
 import { BaseExecutor } from '../base/BaseExecutor'
 import { ClientType } from '../base/Client'
-import { HttpAddress } from '../base/Transports'
+import { HttpAddressInitializer } from '../base/Transports'
 import { discover } from '../http/discover'
 import { HttpClient } from '../http/HttpClient'
 import { WebSocketClient } from '../ws/WebSocketClient'
-import { getLogger } from '@stencila/logga';
+import { getLogger } from '@stencila/logga'
 
 const log = getLogger('executa:browser')
 
@@ -37,12 +37,10 @@ const onReadyHandler = (): void => {
   setCodeChunkProps()
 }
 
-export const init = (options: Partial<InitOptions> = defaultOptions): void => {
-  const { host, port, path, protocol } = { ...defaultOptions, ...options }
-
+export const init = (address: HttpAddressInitializer): void => {
   executor = new BaseExecutor(
-    [() => discover(new HttpAddress({ host, port }, path, protocol))],
-    [HttpClient as ClientType, WebSocketClient as ClientType]
+    [() => discover(address)],
+    [HttpClient, WebSocketClient]
   )
 
   if (document.readyState === 'loading') {
@@ -50,22 +48,6 @@ export const init = (options: Partial<InitOptions> = defaultOptions): void => {
   } else {
     onReadyHandler()
   }
-}
-
-interface InitOptions {
-  host: HttpAddress['host']
-  port: HttpAddress['port']
-  path: HttpAddress['path']
-  protocol: HttpAddress['protocol']
-}
-
-const defaultOptions: InitOptions = {
-  host: window.location.hostname.includes('localhost')
-    ? 'localhost'
-    : 'hub.stenci.la',
-  path: '',
-  port: 9000,
-  protocol: 'jsonrpc'
 }
 
 const executa = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ const main = async () => {
     servers.push(
       new VsockServer(
         new VsockAddress(
-          typeof options.vsock === 'boolean' ? undefined : options.vsock
+          typeof options.vsock === 'boolean' ? 6000 : options.vsock
         )
       )
     )
@@ -54,18 +54,14 @@ const main = async () => {
   if (options.tcp !== undefined) {
     servers.push(
       new TcpServer(
-        new TcpAddress(
-          typeof options.tcp === 'boolean' ? undefined : options.tcp
-        )
+        new TcpAddress(typeof options.tcp === 'boolean' ? 7000 : options.tcp)
       )
     )
   }
   if (options.http !== undefined) {
     servers.push(
       new HttpServer(
-        new HttpAddress(
-          typeof options.http === 'boolean' ? undefined : options.http
-        )
+        new HttpAddress(typeof options.http === 'boolean' ? 8000 : options.http)
       )
     )
   }
@@ -73,7 +69,7 @@ const main = async () => {
     servers.push(
       new WebSocketServer(
         new WebSocketAddress(
-          typeof options.ws === 'boolean' ? undefined : options.ws
+          typeof options.ws === 'boolean' ? 9000 : options.ws
         )
       )
     )

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -8,7 +8,7 @@ import { BaseExecutor } from '../base/BaseExecutor'
 import { InternalError } from '../base/InternalError'
 import { JsonRpcErrorCode } from '../base/JsonRpcError'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
-import { HttpAddress } from '../base/Transports'
+import { HttpAddress, HttpAddressInitializer } from '../base/Transports'
 import { TcpServer } from '../tcp/TcpServer'
 import { JsonRpcResponse } from '../base/JsonRpcResponse'
 
@@ -34,7 +34,9 @@ export class HttpServer extends TcpServer {
    */
   protected defaultJwt: string
 
-  public constructor(address: HttpAddress = new HttpAddress()) {
+  public constructor(
+    address: HttpAddressInitializer = new HttpAddress({ port: 8000 })
+  ) {
     super(address)
 
     // Define the routes
@@ -107,22 +109,18 @@ export class HttpServer extends TcpServer {
   }
 
   public get address(): HttpAddress {
-    return new HttpAddress(
-      {
-        host: this.host,
-        port: this.port
-      },
-      '',
-      'jsonrpc',
-      this.defaultJwt
-    )
+    return new HttpAddress({
+      host: this.host,
+      port: this.port,
+      jwt: this.defaultJwt
+    })
   }
 
   public async start(executor?: Executor): Promise<void> {
     if (executor === undefined) executor = new BaseExecutor()
     this.executor = executor
 
-    const url = this.address.toString()
+    const url = this.address.url()
     log.info(`Starting server: ${url}`)
     return new Promise(resolve =>
       this.app.listen(this.port, this.host, () => {

--- a/src/http/discover.ts
+++ b/src/http/discover.ts
@@ -1,5 +1,5 @@
 import { Manifest } from '../base/Executor'
-import { HttpAddress } from '../base/Transports'
+import { HttpAddressInitializer } from '../base/Transports'
 import { HttpClient } from './HttpClient'
 
 /**
@@ -7,7 +7,9 @@ import { HttpClient } from './HttpClient'
  *
  * Currently just fetches a `Manifest` from a single `HttpAddress`.
  */
-export async function discover(address?: HttpAddress): Promise<Manifest[]> {
+export async function discover(
+  address?: HttpAddressInitializer
+): Promise<Manifest[]> {
   const client = new HttpClient(address)
   const manifest = await client.manifest()
   return [manifest]

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,5 +1,11 @@
+export { Executor, User } from './base/Executor'
 export { BaseExecutor } from './base/BaseExecutor'
-export { init } from './browser/init'
-export { discover as discoverHttp } from './http/discover'
+
+export { HttpAddress } from './base/Transports'
+export { discover as httpDiscover } from './http/discover'
 export { HttpClient } from './http/HttpClient'
+
+export { WebSocketAddress } from './base/Transports'
 export { WebSocketClient } from './ws/WebSocketClient'
+
+export { init } from './browser/init'

--- a/src/stdio/StdioClient.ts
+++ b/src/stdio/StdioClient.ts
@@ -1,23 +1,14 @@
 import { spawn, ChildProcess } from 'child_process'
 import { StreamClient } from '../stream/StreamClient'
-import { StdioAddress } from '../base/Transports'
+import { StdioAddressInitializer, StdioAddress } from '../base/Transports'
 import { getLogger } from '@stencila/logga'
 
 const log = getLogger('executa:stdio:client')
 export class StdioClient extends StreamClient {
   private child: ChildProcess
 
-  public constructor(address: string | Omit<StdioAddress, 'type'>) {
-    let command
-    let args: string[] = []
-    if (typeof address === 'string') {
-      const parts = address.split(/\s/)
-      command = parts[0]
-      args = parts.slice(1)
-    } else {
-      command = address.command
-      if (address.args !== undefined) args = address.args
-    }
+  public constructor(address: StdioAddressInitializer) {
+    const { command, args } = new StdioAddress(address)
 
     const child = spawn(command, args)
     child.on('error', (error: Error) => log.error(error))

--- a/src/stdio/StdioServer.ts
+++ b/src/stdio/StdioServer.ts
@@ -3,10 +3,9 @@ import { StdioAddress, Transport } from '../base/Transports'
 
 export class StdioServer extends StreamServer {
   public get address(): StdioAddress {
-    return {
-      type: Transport.stdio,
+    return new StdioAddress({
       command: process.argv[0],
       args: process.argv.slice(1)
-    }
+    })
   }
 }

--- a/src/tcp/TcpClient.ts
+++ b/src/tcp/TcpClient.ts
@@ -1,18 +1,20 @@
 import { Socket } from 'net'
 import { StreamClient } from '../stream/StreamClient'
 import { getLogger } from '@stencila/logga'
-import { TcpAddress } from '../base/Transports'
+import { TcpAddress, TcpAddressInitializer } from '../base/Transports'
 
 const log = getLogger('executa:tcp:client')
 
 export class TcpClient extends StreamClient {
   private socket: Socket
 
-  public constructor(address: TcpAddress = new TcpAddress()) {
+  public constructor(address: TcpAddressInitializer = new TcpAddress()) {
+    const tcpAddress = new TcpAddress(address)
+    const { host, port } = tcpAddress
+
     const socket = new Socket()
-    const { host, port } = address
     socket.connect(port, host, () => {
-      log.debug(`Connection open: ${address.toString()}`)
+      log.debug(`Connection open: ${tcpAddress.url()}`)
     })
     socket.on('close', () => {
       log.debug(`Connection closed: ${host}:${port}`)

--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -2,7 +2,10 @@ import WebSocket, { ErrorEvent, MessageEvent } from 'isomorphic-ws'
 
 import { Client } from '../base/Client'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
-import { WebSocketAddress } from '../base/Transports'
+import {
+  WebSocketAddress,
+  WebSocketAddressInitializer
+} from '../base/Transports'
 import { getLogger } from '@stencila/logga'
 
 const log = getLogger('executa:ws:client')
@@ -19,12 +22,13 @@ export class WebSocketClient extends Client {
    */
   private socket: WebSocket
 
-  public constructor(address: WebSocketAddress = new WebSocketAddress()) {
+  public constructor(
+    address: WebSocketAddressInitializer = new WebSocketAddress()
+  ) {
     super()
 
-    const { host = '127.0.1.1', port = '9000', path = '', jwt } = address
-    const url = `ws://${host}:${port}${path}`
-    const socket = (this.socket = new WebSocket(url, jwt))
+    const wsAddress = new WebSocketAddress(address)
+    const socket = (this.socket = new WebSocket(wsAddress.url(), wsAddress.jwt))
 
     socket.onerror = (error: ErrorEvent) => log.error(error.message)
     socket.onmessage = (event: MessageEvent) =>

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -3,7 +3,10 @@ import { getLogger } from '@stencila/logga'
 import fastifyWebsocket from 'fastify-websocket'
 import jwt from 'jsonwebtoken'
 import { InternalError } from '../base/InternalError'
-import { WebSocketAddress } from '../base/Transports'
+import {
+  WebSocketAddress,
+  WebSocketAddressInitializer
+} from '../base/Transports'
 import { HttpServer } from '../http/HttpServer'
 import { TcpServerClient, tcpServerClient } from '../tcp/TcpServer'
 
@@ -24,8 +27,12 @@ export class WebSocketServer extends HttpServer {
    */
   users: { [key: string]: any } = {}
 
-  public constructor(address: WebSocketAddress = new WebSocketAddress()) {
+  public constructor(
+    address: WebSocketAddressInitializer = new WebSocketAddress({ port: 9000 })
+  ) {
     super(address)
+    console.log(address)
+    console.log(this.address.url())
 
     // Verify the JWT for each connection and store
     // it's payload so it can be used against each
@@ -82,14 +89,11 @@ export class WebSocketServer extends HttpServer {
   }
 
   public get address(): WebSocketAddress {
-    return new WebSocketAddress(
-      {
-        host: this.host,
-        port: this.port
-      },
-      '',
-      this.defaultJwt
-    )
+    return new WebSocketAddress({
+      host: this.host,
+      port: this.port,
+      jwt: this.defaultJwt
+    })
   }
 
   /**


### PR DESCRIPTION
This refactors how `Address`es are initialised. It provides more flexibility than the previous approach e.g. a `HttpClient` can be constructed from a string or from an object with `host`, `port` etc. and allows for both `https` and `wss`.

Supersedes #22