### PR TITLE
feat(WebSocket): Client side ids and re-connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1517,9 +1517,9 @@
       }
     },
     "@stencila/logga": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-1.4.0.tgz",
-      "integrity": "sha512-xHSE0IAn+LmOBX8JnhTsTqbECYaNc7rzNDDMaMyAeS8UL8zOYCwIwChMD1lIDJXkHi5KCxIiFUQiLhq0Ujy/ig=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-1.4.1.tgz",
+      "integrity": "sha512-Qu9zlLTRR0ZAH++nUeZ62HzSylycRMbZKX+uARXYaHNHnaQv0ghFxm5mpQbl0/fW7aPEDq8ewE/jYpQyXeZmLA=="
     },
     "@stencila/schema": {
       "version": "0.31.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1726,8 +1726,7 @@
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/semver": {
       "version": "6.0.2",
@@ -13127,10 +13126,9 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
-      "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
       "requires": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
@@ -14159,8 +14157,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,6 +1703,15 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
+    "@types/nanoid": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/nanoid/-/nanoid-2.1.0.tgz",
+      "integrity": "sha512-xdkn/oRTA0GSNPLIKZgHWqDTWZsVrieKomxJBOQUK9YDD+zfSgmwD5t4WJYra5S7XyhTw7tfvwznW+pFexaepQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "12.7.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
@@ -9176,6 +9185,11 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.6.tgz",
+      "integrity": "sha512-2NDzpiuEy3+H0AVtdt8LoFi7PnqkOnIzYmJQp7xsEU6VexLluHQwKREuiz57XaQC5006seIadPrIZJhyS2n7aw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "24.0.21",
     "@types/json-schema": "7.0.3",
     "@types/minimist": "1.2.0",
+    "@types/nanoid": "^2.1.0",
     "jest": "24.9.0",
     "markdown-toc": "1.2.0",
     "rollup": "1.26.3",
@@ -64,6 +65,7 @@
     "isomorphic-ws": "^4.0.1",
     "length-prefixed-stream": "^2.0.0",
     "minimist": "^1.2.0",
+    "nanoid": "^2.1.6",
     "p-retry": "^4.2.0"
   },
   "prettier": "@stencila/dev-config/prettier-config.json",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "3.6.4"
   },
   "dependencies": {
-    "@stencila/logga": "^1.4.0",
+    "@stencila/logga": "^1.4.1",
     "@stencila/schema": "^0.31.0",
     "@types/ws": "^6.0.3",
     "ajv": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "glob": "^7.1.4",
     "isomorphic-ws": "^4.0.1",
     "length-prefixed-stream": "^2.0.0",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "p-retry": "^4.2.0"
   },
   "prettier": "@stencila/dev-config/prettier-config.json",
   "commitlint": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,9 @@ export default [
         exclude: 'node_modules/**'
       }),
       builtins(),
-      resolve()
+      resolve({
+        mainFields: ['browser', 'module', 'main']
+      })
     ],
 
     // Do not bundle modules that provide things already

--- a/src/base/uid.ts
+++ b/src/base/uid.ts
@@ -1,0 +1,18 @@
+import generate from 'nanoid/generate'
+
+/**
+ * Generate a unique id.
+ *
+ * Generates an id of 22 characters using Roman digits + lowercase and uppercase letters
+ * (i.e. is URL safe and excludes the characters like hyphen or underscore).
+ * This makes the ids a little more readable than those from the default `nanoid` settings
+ * while still having an extremely low collision probability on par with UUID v4.
+ *
+ * @see {@link https://zelark.github.io/nano-id-cc/|Nano ID Collision Calculator}
+ */
+export function uid(): string {
+  return generate(
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+    22
+  )
+}

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -215,7 +215,7 @@ export class HttpServer extends TcpServer {
     const url = this.address.url()
     log.info(`Starting server: ${url}`)
 
-    const app = this.app = this.buildApp()
+    const app = (this.app = this.buildApp())
 
     // Wait for plugins to be ready before using them
     await app.ready()

--- a/src/tcp/TcpServer.ts
+++ b/src/tcp/TcpServer.ts
@@ -79,10 +79,12 @@ export class TcpServer extends Server {
   }
 
   protected onConnected(connection: Connection): void {
+    log.info(`Client connected: ${connection.id}`)
     this.connections[connection.id] = connection
   }
 
   protected onDisconnected(connection: Connection): void {
+    log.info(`Client disconnected: ${connection.id}`)
     delete this.connections[connection.id]
   }
 
@@ -128,14 +130,14 @@ export class TcpServer extends Server {
   }
 
   public async stop(): Promise<void> {
+    Object.values(this.connections).forEach(connection => {
+      connection.stop().catch(error => log.error(error))
+    })
+    this.connections = {}
+
     if (this.server !== undefined) {
       const url = this.address.url()
       log.info(`Stopping server ${url}`)
-
-      Object.values(this.connections).forEach(connection => {
-        connection.stop().catch(error => log.error(error))
-      })
-      this.connections = {}
 
       return new Promise(resolve => {
         if (this.server !== undefined)

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -131,7 +131,7 @@ test('WebSocketClient and WebSocketServer', async () => {
     expect(serverConnections()).toBe(0)
 
     await server.start()
-    await delay(10)
+    await delay(100)
 
     expect(serverConnections()).toBe(3)
     expect(clientLogs.length).toBe(3)

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -85,25 +85,35 @@ test('WebSocketClient and WebSocketServer', async () => {
   {
     // Client with malformed JWT
     clientLogs = []
-    const client = new WebSocketClient({ ...server.address, jwt: 'jwhaaaat?' }, 'malformed-jwt')
+    const client = new WebSocketClient(
+      { ...server.address, jwt: 'jwhaaaat?' },
+      'malformed-jwt'
+    )
     await delay(10)
     expect(serverConnections()).toBe(0)
     expect(clientLogs.length).toBe(1)
-    expect(clientLogs[0].message).toMatch(/Failed to authenticate with server: jwt malformed/)
+    expect(clientLogs[0].message).toMatch(
+      /Failed to authenticate with server: jwt malformed/
+    )
     await client.stop()
   }
 
   {
     // Client with invalid JWT
     clientLogs = []
-    const client = new WebSocketClient({
-      ...server.address,
-      jwt: JWT.sign({}, 'not-the-right-secret')
-    }, 'invalid-jwt')
+    const client = new WebSocketClient(
+      {
+        ...server.address,
+        jwt: JWT.sign({}, 'not-the-right-secret')
+      },
+      'invalid-jwt'
+    )
     await delay(10)
     expect(serverConnections()).toBe(0)
     expect(clientLogs.length).toBe(1)
-    expect(clientLogs[0].message).toMatch(/Failed to authenticate with server: invalid signature/)
+    expect(clientLogs[0].message).toMatch(
+      /Failed to authenticate with server: invalid signature/
+    )
     await client.stop()
   }
 
@@ -125,8 +135,9 @@ test('WebSocketClient and WebSocketServer', async () => {
 
     expect(serverConnections()).toBe(3)
     expect(clientLogs.length).toBe(3)
-    expect(clientLogs[0].message).toMatch(/Connection closed, trying to reconnect/)
-
+    expect(clientLogs[0].message).toMatch(
+      /Connection closed, trying to reconnect/
+    )
 
     await client1.stop()
     await client2.stop()

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -12,8 +12,8 @@ import {
 } from '../base/Transports'
 import { HttpServer } from '../http/HttpServer'
 import { send, isOpen } from './util'
-import { User } from '../base/Executor';
-import { FastifyRequest, FastifyInstance } from 'fastify';
+import { User } from '../base/Executor'
+import { FastifyRequest, FastifyInstance } from 'fastify'
 
 const log = getLogger('executa:ws:server')
 
@@ -37,10 +37,14 @@ export class WebSocketConnection implements Connection {
    */
   socket: WebSocket
 
-  constructor(socket: WebSocket, id: string, payload: {[key:string]: string}) {
+  constructor(
+    socket: WebSocket,
+    id: string,
+    payload: { [key: string]: string }
+  ) {
     this.socket = socket
     this.id = id
-    this.user = {...payload, client: {type: Transport.ws, id}}
+    this.user = { ...payload, client: { type: Transport.ws, id } }
   }
 
   /**
@@ -88,7 +92,6 @@ export class WebSocketConnection implements Connection {
  * A `Server` using WebSockets as the transport protocol.
  */
 export class WebSocketServer extends HttpServer {
-
   public constructor(
     address: WebSocketAddressInitializer = new WebSocketAddress({ port: 9000 })
   ) {
@@ -110,16 +113,18 @@ export class WebSocketServer extends HttpServer {
         const [id, token] = socket.protocol.split(':')
         let payload
         try {
-          payload = app.jwt.verify(token) as {}
+          payload = app.jwt.verify(token)
         } catch (error) {
           socket.close(4001, error.message)
           return
         }
 
         // Register connection and disconnection handler
-        const wsconnection = new WebSocketConnection(socket, id, payload)
+        const wsconnection = new WebSocketConnection(socket, id, payload as {
+          [key: string]: string
+        })
         this.onConnected(wsconnection)
-        socket.on('close', () =>  this.onDisconnected(wsconnection))
+        socket.on('close', () => this.onDisconnected(wsconnection))
 
         // Handle messages from connection
         socket.on('message', async (message: string) => {
@@ -127,7 +132,7 @@ export class WebSocketServer extends HttpServer {
           if (response !== undefined)
             wsconnection
               .send(response as string)
-              .catch(error => log.error(error))
+              .catch((error: Error) => log.error(error))
         })
 
         // Handle any errors

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -1,6 +1,5 @@
 import { getLogger } from '@stencila/logga'
 import { Node } from '@stencila/schema'
-import crypto from 'crypto'
 // @ts-ignore
 import fastifyWebsocket from 'fastify-websocket'
 import WebSocket from 'isomorphic-ws'
@@ -8,10 +7,13 @@ import { Connection } from '../base/Connection'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 import {
   WebSocketAddress,
-  WebSocketAddressInitializer
+  WebSocketAddressInitializer,
+  Transport
 } from '../base/Transports'
 import { HttpServer } from '../http/HttpServer'
 import { send, isOpen } from './util'
+import { User } from '../base/Executor';
+import { FastifyRequest, FastifyInstance } from 'fastify';
 
 const log = getLogger('executa:ws:server')
 
@@ -21,17 +23,24 @@ const log = getLogger('executa:ws:server')
 export class WebSocketConnection implements Connection {
   /**
    * @implements Implements {@link Connection.id} to provide
-   * a unique id for the WebSocket connection.
+   * a unique id for the WebSocket client.
    */
-  id: string = crypto.randomBytes(32).toString('hex')
+  id: string
+
+  /**
+   * User information for this connection
+   */
+  user: User
 
   /**
    * The WebSocket used by this connection
    */
   socket: WebSocket
 
-  constructor(socket: WebSocket) {
+  constructor(socket: WebSocket, id: string, payload: {[key:string]: string}) {
     this.socket = socket
+    this.id = id
+    this.user = {...payload, client: {type: Transport.ws, id}}
   }
 
   /**
@@ -79,52 +88,42 @@ export class WebSocketConnection implements Connection {
  * A `Server` using WebSockets as the transport protocol.
  */
 export class WebSocketServer extends HttpServer {
-  /**
-   * A map of JWT tokens to their payload.
-   *
-   * This is necessary, because we need to keep provide the
-   * JWT payload to `this.executor` on each message.
-   * In `HttpServer` this is easy because the payload is
-   * attached to the request as the `user` property.
-   * Here, we need to do the association ourselves.
-   */
-  users: { [key: string]: any } = {}
 
   public constructor(
     address: WebSocketAddressInitializer = new WebSocketAddress({ port: 9000 })
   ) {
     super(address)
+  }
 
-    this.app.register(fastifyWebsocket, {
-      handle: (connection: any) => {
+  /**
+   * @override Overrides {@link HttpServer.buildApp} to add WebSocket
+   * handling.
+   */
+  protected buildApp(): FastifyInstance {
+    const app = super.buildApp()
+    app.register(fastifyWebsocket, {
+      handle: (connection: any, request: FastifyRequest) => {
         const { socket } = connection
 
-        const token = socket.protocol
-        const user = this.users[token]
-        if (user === undefined) {
-          // This should not happen
-          log.error('Unable to get user for connection')
+        // Extract id and token from the protocol ('sec-websocket-protocol' header)
+        // and verify the token
+        const [id, token] = socket.protocol.split(':')
+        let payload
+        try {
+          payload = app.jwt.verify(token) as {}
+        } catch (error) {
+          socket.close(4001, error.message)
+          return
         }
 
         // Register connection and disconnection handler
-        const wsconnection = new WebSocketConnection(socket)
+        const wsconnection = new WebSocketConnection(socket, id, payload)
         this.onConnected(wsconnection)
-        socket.on('close', () => {
-          this.onDisconnected(wsconnection)
-          delete this.users[token]
-        })
+        socket.on('close', () =>  this.onDisconnected(wsconnection))
 
         // Handle messages from connection
         socket.on('message', async (message: string) => {
-          const response = await this.receive(message, {
-            // The `user` argument is a merging of the JWT
-            // payload and client identification info.
-            ...user,
-            client: {
-              type: 'ws',
-              id: wsconnection.id
-            }
-          })
+          const response = await this.receive(message, wsconnection.user)
           if (response !== undefined)
             wsconnection
               .send(response as string)
@@ -133,21 +132,9 @@ export class WebSocketServer extends HttpServer {
 
         // Handle any errors
         socket.on('error', (error: Error) => log.error(error))
-      },
-      options: {
-        verifyClient: (info: any, next: (ok: boolean) => void): void => {
-          const { headers } = info.req
-          const token = headers['sec-websocket-protocol']
-          if (token === undefined) return next(false)
-          try {
-            this.users[token] = this.app.jwt.verify(token)
-            next(true)
-          } catch {
-            next(false)
-          }
-        }
       }
     })
+    return app
   }
 
   public get address(): WebSocketAddress {


### PR DESCRIPTION
Moves the generation of unique ids for each WebSocket client from the server to the client. This enables re-connections to be performed while maintaining the client id (which may be used in session limits).