### PR TITLE
fix(Client): Do not throw error on bad message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,9 +1702,9 @@
       }
     },
     "@stencila/logga": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-1.4.1.tgz",
-      "integrity": "sha512-Qu9zlLTRR0ZAH++nUeZ62HzSylycRMbZKX+uARXYaHNHnaQv0ghFxm5mpQbl0/fW7aPEDq8ewE/jYpQyXeZmLA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-2.0.0.tgz",
+      "integrity": "sha512-gt78QGjjJ1uajlceFcmAdi2IwbmvL/IkgxmNs5mf+zZdM9l1YmN4mw6eZz+a8xdRQEpOxbD/s+NZ5z6k9/rlYg=="
     },
     "@stencila/schema": {
       "version": "0.31.0",
@@ -1720,6 +1720,11 @@
         "minimist": "^1.2.0"
       },
       "dependencies": {
+        "@stencila/logga": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-1.4.1.tgz",
+          "integrity": "sha512-Qu9zlLTRR0ZAH++nUeZ62HzSylycRMbZKX+uARXYaHNHnaQv0ghFxm5mpQbl0/fW7aPEDq8ewE/jYpQyXeZmLA=="
+        },
         "get-stdin": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "3.6.4"
   },
   "dependencies": {
-    "@stencila/logga": "^1.4.1",
+    "@stencila/logga": "^2.0.0",
     "@stencila/schema": "^0.31.0",
     "@types/ws": "^6.0.3",
     "ajv": "^6.10.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ const log = getLogger('executa:cli')
 
 replaceHandlers(data =>
   defaultHandler(data, {
-    level: options.debug !== undefined ? LogLevel.debug : LogLevel.info
+    maxLevel: options.debug !== undefined ? LogLevel.debug : LogLevel.info
   })
 )
 

--- a/src/console.ts
+++ b/src/console.ts
@@ -48,7 +48,7 @@ replaceHandlers(data => {
   const { level } = data
   if (level <= (options.debug !== undefined ? LogLevel.debug : LogLevel.warn)) {
     process.stderr.write(`--- `)
-    defaultHandler(data, { level: LogLevel.debug })
+    defaultHandler(data, { maxLevel: LogLevel.debug })
   }
 })
 

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -3,6 +3,12 @@ import { StdioClient } from './StdioClient'
 import { testClient } from '../test/testClient'
 import { nextLogData } from '../test/nextLogData'
 
+// Some of these tests take time to run
+// due to spawning a ts-node process, so
+// increase timeout to avoid this:
+// https://travis-ci.org/stencila/executa/jobs/614741283#L381
+jest.setTimeout(30 * 1000)
+
 describe('StdioClient and StdioServer', () => {
   const testServer = (arg = ''): string =>
     `npx ts-node --files ${path.join(__dirname, 'stdioTestServer.ts')} ${arg}`

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -54,8 +54,8 @@ describe('StdioClient and StdioServer', () => {
     test('crash-on-start', async () => {
       const client = new StdioClient(testServer('crash-on-start'))
       await delay(20 * 1000)
-      expect(clientLogs.length).toBe(2)
-      expect(clientLogs[1].message).toMatch(
+      expect(clientLogs.length).toBe(3)
+      expect(clientLogs[2].message).toMatch(
         /^Server exited prematurely with exit code 1 and signal null/
       )
       await client.stop()
@@ -64,8 +64,8 @@ describe('StdioClient and StdioServer', () => {
     test('exit-prematurely', async () => {
       const client = new StdioClient(testServer('exit-prematurely'))
       await delay(20 * 1000)
-      expect(clientLogs.length).toBe(3)
-      expect(clientLogs[2].message).toMatch(
+      expect(clientLogs.length).toBe(4)
+      expect(clientLogs[3].message).toMatch(
         /^Server exited prematurely with exit code 0 and signal null/
       )
       await client.stop()

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -4,7 +4,7 @@ import { testClient } from '../test/testClient'
 import { addHandler, LogData } from '@stencila/logga'
 import { delay } from '../test/delay'
 
-jest.setTimeout(30 * 1000)
+jest.setTimeout(2 * 60 * 1000)
 
 describe('StdioClient and StdioServer', () => {
   const testServer = (arg = ''): string =>
@@ -36,7 +36,9 @@ describe('StdioClient and StdioServer', () => {
       /^Error parsing message as JSON: ah hah/
     )
 
-    client.decode('crash now!')
+    client.decode('crash now!').catch(error => {
+      throw error
+    })
     await delay(250)
     expect(clientLogs.length).toBe(2)
     expect(clientLogs[1].message).toMatch(
@@ -51,7 +53,7 @@ describe('StdioClient and StdioServer', () => {
   if (process.env.CI !== undefined) {
     test('crash-on-start', async () => {
       const client = new StdioClient(testServer('crash-on-start'))
-      await delay(10000)
+      await delay(20 * 1000)
       expect(clientLogs.length).toBe(2)
       expect(clientLogs[1].message).toMatch(
         /^Server exited prematurely with exit code 1 and signal null/
@@ -61,7 +63,7 @@ describe('StdioClient and StdioServer', () => {
 
     test('exit-prematurely', async () => {
       const client = new StdioClient(testServer('exit-prematurely'))
-      await delay(10000)
+      await delay(20 * 1000)
       expect(clientLogs.length).toBe(3)
       expect(clientLogs[2].message).toMatch(
         /^Server exited prematurely with exit code 0 and signal null/

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -13,8 +13,8 @@ describe('StdioClient and StdioServer', () => {
   const testServer = (arg = ''): string =>
     `npx ts-node --files ${path.join(__dirname, 'stdioTestServer.ts')} ${arg}`
 
-  const nextClientLogData = () =>
-    nextLogData(['executa:client', 'executa:stdio:client'])
+  const nextMessage = async () =>
+    (await nextLogData(['executa:client', 'executa:stdio:client'])).message
 
   test('main', async () => {
     const client = new StdioClient(testServer())
@@ -26,20 +26,16 @@ describe('StdioClient and StdioServer', () => {
     client.decode('send bad message').catch(error => {
       throw error
     })
-    {
-      const logData = await nextClientLogData()
-      expect(logData.message).toMatch(/^Error parsing message as JSON: ah hah/)
-    }
+    expect(await nextMessage()).toMatch(
+      /^Error parsing message as JSON: ah hah/
+    )
 
     client.decode('crash now!').catch(error => {
       throw error
     })
-    {
-      const logData = await nextClientLogData()
-      expect(logData.message).toMatch(
-        /^Server exited prematurely with exit code 1 and signal null/
-      )
-    }
+    expect(await nextMessage()).toMatch(
+      /^Server exited prematurely with exit code 1 and signal null/
+    )
 
     await client.stop()
   })
@@ -50,8 +46,7 @@ describe('StdioClient and StdioServer', () => {
   if (process.env.CI !== undefined) {
     test('crash-on-start', async () => {
       const client = new StdioClient(testServer('crash-on-start'))
-      const logData = await nextClientLogData()
-      expect(logData.message).toMatch(
+      expect(await nextMessage()).toMatch(
         /^Server exited prematurely with exit code 1 and signal null/
       )
       await client.stop()
@@ -59,8 +54,7 @@ describe('StdioClient and StdioServer', () => {
 
     test('exit-prematurely', async () => {
       const client = new StdioClient(testServer('exit-prematurely'))
-      const logData = await nextClientLogData()
-      expect(logData.message).toMatch(
+      expect(await nextMessage()).toMatch(
         /^Server exited prematurely with exit code 0 and signal null/
       )
       await client.stop()

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -1,24 +1,14 @@
 import path from 'path'
 import { StdioClient } from './StdioClient'
 import { testClient } from '../test/testClient'
-import { addHandler, LogData } from '@stencila/logga'
-import { delay } from '../test/delay'
-
-jest.setTimeout(2 * 60 * 1000)
+import { nextLogData } from '../test/nextLogData'
 
 describe('StdioClient and StdioServer', () => {
   const testServer = (arg = ''): string =>
     `npx ts-node --files ${path.join(__dirname, 'stdioTestServer.ts')} ${arg}`
 
-  let clientLogs: LogData[] = []
-  addHandler((logData: LogData) => {
-    if (
-      logData.tag === 'executa:client' ||
-      logData.tag === 'executa:stdio:client'
-    ) {
-      clientLogs = [...clientLogs, logData]
-    }
-  })
+  const nextClientLogData = () =>
+    nextLogData(['executa:client', 'executa:stdio:client'])
 
   test('main', async () => {
     const client = new StdioClient(testServer())
@@ -30,32 +20,32 @@ describe('StdioClient and StdioServer', () => {
     client.decode('send bad message').catch(error => {
       throw error
     })
-    await delay(250)
-    expect(clientLogs.length).toBe(1)
-    expect(clientLogs[0].message).toMatch(
-      /^Error parsing message as JSON: ah hah/
-    )
+    {
+      const logData = await nextClientLogData()
+      expect(logData.message).toMatch(/^Error parsing message as JSON: ah hah/)
+    }
 
     client.decode('crash now!').catch(error => {
       throw error
     })
-    await delay(250)
-    expect(clientLogs.length).toBe(2)
-    expect(clientLogs[1].message).toMatch(
-      /^Server exited prematurely with exit code 1 and signal null/
-    )
+    {
+      const logData = await nextClientLogData()
+      expect(logData.message).toMatch(
+        /^Server exited prematurely with exit code 1 and signal null/
+      )
+    }
 
     await client.stop()
   })
 
-  // These tests require waiting to be sure that the process
-  // has had chance to start and crash, so only run on CI
+  // These tests add ~5s to test run time (involve starting more ts-node processes)
+  // and are somewhat redundant given last 'crash now' test above.
+  // So to keep test run times low during development they are only run on CI.
   if (process.env.CI !== undefined) {
     test('crash-on-start', async () => {
       const client = new StdioClient(testServer('crash-on-start'))
-      await delay(20 * 1000)
-      expect(clientLogs.length).toBe(3)
-      expect(clientLogs[2].message).toMatch(
+      const logData = await nextClientLogData()
+      expect(logData.message).toMatch(
         /^Server exited prematurely with exit code 1 and signal null/
       )
       await client.stop()
@@ -63,9 +53,8 @@ describe('StdioClient and StdioServer', () => {
 
     test('exit-prematurely', async () => {
       const client = new StdioClient(testServer('exit-prematurely'))
-      await delay(20 * 1000)
-      expect(clientLogs.length).toBe(4)
-      expect(clientLogs[3].message).toMatch(
+      const logData = await nextClientLogData()
+      expect(logData.message).toMatch(
         /^Server exited prematurely with exit code 0 and signal null/
       )
       await client.stop()

--- a/src/stdio/StdioClientServer.test.ts
+++ b/src/stdio/StdioClientServer.test.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import { StdioClient } from './StdioClient'
 import { testClient } from '../test/testClient'
+import { addHandler, LogData } from '@stencila/logga'
+import { delay } from '../test/delay'
 
 jest.setTimeout(30 * 1000)
 
@@ -8,9 +10,63 @@ describe('StdioClient and StdioServer', () => {
   const testServer = (arg = ''): string =>
     `npx ts-node --files ${path.join(__dirname, 'stdioTestServer.ts')} ${arg}`
 
-  test('all-is-ok', async () => {
+  let clientLogs: LogData[] = []
+  addHandler((logData: LogData) => {
+    if (
+      logData.tag === 'executa:client' ||
+      logData.tag === 'executa:stdio:client'
+    ) {
+      clientLogs = [...clientLogs, logData]
+    }
+  })
+
+  test('main', async () => {
     const client = new StdioClient(testServer())
     await testClient(client)
+
+    // Do not await the next two calls to `decode` - they do not
+    // resolve due to the bad message
+
+    client.decode('send bad message').catch(error => {
+      throw error
+    })
+    await delay(250)
+    expect(clientLogs.length).toBe(1)
+    expect(clientLogs[0].message).toMatch(
+      /^Error parsing message as JSON: ah hah/
+    )
+
+    client.decode('crash now!')
+    await delay(250)
+    expect(clientLogs.length).toBe(2)
+    expect(clientLogs[1].message).toMatch(
+      /^Server exited prematurely with exit code 1 and signal null/
+    )
+
     await client.stop()
   })
+
+  // These tests require waiting to be sure that the process
+  // has had chance to start and crash, so only run on CI
+  if (process.env.CI !== undefined) {
+    test('crash-on-start', async () => {
+      const client = new StdioClient(testServer('crash-on-start'))
+      await delay(10000)
+      expect(clientLogs.length).toBe(2)
+      expect(clientLogs[1].message).toMatch(
+        /^Server exited prematurely with exit code 1 and signal null/
+      )
+      await client.stop()
+    })
+
+    test('exit-prematurely', async () => {
+      const client = new StdioClient(testServer('exit-prematurely'))
+      await delay(10000)
+      expect(clientLogs.length).toBe(3)
+      expect(clientLogs[2].message).toMatch(
+        /^Server exited prematurely with exit code 0 and signal null/
+      )
+      await client.stop()
+    })
+  }
 })

--- a/src/stdio/stdioTestServer.ts
+++ b/src/stdio/stdioTestServer.ts
@@ -1,15 +1,33 @@
 /**
  * Used as a test server by `StdioClientServer.test.ts`
  *
- * Call with one of these args to simulate various errors:
+ * Run with one of these args to simulate various errors:
  *
  * - `crash-on-start`
  * - `exit-prematurely`
- * - `crash-on-request`
+ *
+ * Or call the decode method e.g.
+ *
+ * - `client.decode('crash now!')`
  */
 
 import { StdioServer } from './StdioServer'
+import { BaseExecutor } from '../base/BaseExecutor'
+import { Node } from '@stencila/schema'
 
+class TestExecutor extends BaseExecutor {
+  decode(content: string): Promise<Node> {
+    if (content === 'send bad message') {
+      process.stdout.write('Hah hah, a bad message to try to crash you!')
+      return Promise.resolve('bad message sent')
+    } else if (content === 'crash now!') {
+      setTimeout(() => process.exit(1), 100)
+      return Promise.resolve('crashing soon')
+    } else return super.decode(content)
+  }
+}
+
+const executor = new TestExecutor()
 const server = new StdioServer()
 
 const arg = process.argv[2]
@@ -17,14 +35,8 @@ if (arg === 'crash-on-start') {
   process.exit(1)
 } else if (arg === 'exit-prematurely') {
   setTimeout(() => process.exit(0), 500)
-} else if (arg === 'crash-on-request') {
-  // Mess with the server's executor so that when a request comes in it fails.
-  // @ts-ignore that executor is private
-  server.executor = {
-    decode: () => process.exit(1)
-  }
 }
 
-server.run().catch(error => {
+server.start(executor).catch(error => {
   throw error
 })

--- a/src/test/nextLogData.ts
+++ b/src/test/nextLogData.ts
@@ -6,7 +6,7 @@ import { addHandler, LogData, removeHandler } from '@stencila/logga'
  *
  * @param tags A list of tags that the log data must have
  */
-export const nextLogData = (tags: string[]): Promise<LogData> => {
+export const nextLogData = (tags?: string[]): Promise<LogData> => {
   return new Promise(resolve => {
     const handler = addHandler(
       (logData: LogData) => {

--- a/src/test/nextLogData.ts
+++ b/src/test/nextLogData.ts
@@ -1,0 +1,19 @@
+import { addHandler, LogData, removeHandler } from '@stencila/logga'
+
+/**
+ * Get a promise that resolves to the next log data that
+ * matches the supplied tags.
+ *
+ * @param tags A list of tags that the log data must have
+ */
+export const nextLogData = (tags: string[]): Promise<LogData> => {
+  return new Promise(resolve => {
+    const handler = (logData: LogData) => {
+      if (tags.includes(logData.tag)) {
+        resolve(logData)
+        removeHandler(handler)
+      }
+    }
+    addHandler(handler)
+  })
+}

--- a/src/test/nextLogData.ts
+++ b/src/test/nextLogData.ts
@@ -8,12 +8,12 @@ import { addHandler, LogData, removeHandler } from '@stencila/logga'
  */
 export const nextLogData = (tags: string[]): Promise<LogData> => {
   return new Promise(resolve => {
-    const handler = (logData: LogData) => {
-      if (tags.includes(logData.tag)) {
+    const handler = addHandler(
+      (logData: LogData) => {
         resolve(logData)
         removeHandler(handler)
-      }
-    }
-    addHandler(handler)
+      },
+      { tags }
+    )
   })
 }


### PR DESCRIPTION
Closes #41. A remaining, related, issue is that a bad message will mean that a call to a client message never resolves. Approaches to that (for another PR) could include:

- `reject` _all_ outstanding client requests
- have a timeout on client requests