### PR TITLE
feat(Executor): Node querying

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,7 @@
   "typescript.updateImportsOnFileMove.enabled": "prompt",
   "workbench.editor.highlightModifiedTabs": true,
   "cSpell.words": [
+    "JMES",
     "configa",
     "deparse",
     "executa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2540,6 +2540,12 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "@types/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-SgFikJaoYjHIkaDi3szBX1PJKR0=",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -9893,6 +9899,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "jquery": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
@@ -11209,9 +11220,9 @@
       }
     },
     "npm": {
-      "version": "6.13.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.2.tgz",
-      "integrity": "sha512-TG7AFkKpjBNJh8OVJYcGaAbW0PZxEkjew51Lc6TRdhQpNjSSEnAOEpidApqEuciB7cs09C8mxbo8NbuPs4QDzg==",
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.4.tgz",
+      "integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -11220,7 +11231,7 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.3",
+        "bin-links": "^1.1.6",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
         "cacache": "^12.0.3",
@@ -11241,7 +11252,7 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.2.1",
+        "gentle-fs": "^2.3.0",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
@@ -11290,7 +11301,7 @@
         "npm-install-checks": "^3.0.2",
         "npm-lifecycle": "^3.1.4",
         "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.6",
+        "npm-packlist": "^1.4.7",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.2",
         "npm-registry-fetch": "^4.0.2",
@@ -11299,7 +11310,7 @@
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.9",
+        "pacote": "^9.5.11",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -11308,7 +11319,7 @@
         "read": "~1.0.7",
         "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.1.0",
+        "read-package-json": "^2.1.1",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.4.0",
         "readdir-scoped-modules": "^1.1.0",
@@ -11502,14 +11513,15 @@
           }
         },
         "bin-links": {
-          "version": "1.1.3",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cmd-shim": "^3.0.0",
-            "gentle-fs": "^2.0.1",
+            "gentle-fs": "^2.3.0",
             "graceful-fs": "^4.1.15",
+            "npm-normalize-package-bin": "^1.0.0",
             "write-file-atomic": "^2.3.0"
           }
         },
@@ -12368,12 +12380,13 @@
           "dev": true
         },
         "gentle-fs": {
-          "version": "2.2.1",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
             "chownr": "^1.1.2",
+            "cmd-shim": "^3.0.3",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
@@ -13340,9 +13353,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -13377,6 +13393,11 @@
           "bundled": true,
           "dev": true
         },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "npm-package-arg": {
           "version": "6.1.1",
           "bundled": true,
@@ -13389,7 +13410,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.4.6",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13571,7 +13592,7 @@
           }
         },
         "pacote": {
-          "version": "9.5.9",
+          "version": "9.5.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13589,6 +13610,7 @@
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
+            "npm-normalize-package-bin": "^1.0.0",
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
             "npm-pick-manifest": "^3.0.0",
@@ -13862,7 +13884,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -13870,7 +13892,7 @@
             "graceful-fs": "^4.1.2",
             "json-parse-better-errors": "^1.0.1",
             "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "npm-normalize-package-bin": "^1.0.0"
           }
         },
         "read-package-tree": {
@@ -14042,11 +14064,6 @@
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@gerrit0/typedoc": "0.15.11",
     "@stencila/dev-config": "^1.3.1",
     "@types/jest": "24.0.23",
+    "@types/jmespath": "^0.15.0",
     "@types/json-schema": "7.0.3",
     "@types/lolex": "^5.1.0",
     "@types/minimist": "1.2.0",
@@ -73,6 +74,7 @@
     "fastify-websocket": "^0.6.0",
     "glob": "^7.1.4",
     "isomorphic-ws": "^4.0.1",
+    "jmespath": "^0.15.0",
     "length-prefixed-stream": "^2.0.0",
     "mkdirp": "^0.5.1",
     "nanoid": "^2.1.6",
@@ -110,6 +112,9 @@
     "testEnvironment": "node",
     "testMatch": [
       "<rootDir>/src/**/*.test.[jt]s"
+    ],
+    "coveragePathIgnorePatterns": [
+      "test/*"
     ]
   },
   "husky": {

--- a/src/base/Executor.ts
+++ b/src/base/Executor.ts
@@ -19,7 +19,7 @@ export enum Method {
   manifest = 'manifest',
   decode = 'decode',
   encode = 'encode',
-  select = 'select',
+  query = 'query',
   compile = 'compile',
   build = 'build',
   execute = 'execute',
@@ -191,18 +191,19 @@ export abstract class Executor {
   }
 
   /**
-   * Select a child from a `Node` using a JSON Pointer.
+   * Query a `Node`.
    *
-   * Replaces `~1` with `/` and `~0` with `~` as per
-   * [RFC 6901](https://tools.ietf.org/html/rfc6901#section-4).
+   * Currently allows for two query languages:
    *
-   * @see {@link https://tools.ietf.org/html/rfc6901|JSON Pointer RFC}
+   * - [JMESPath](http://jmespath.org/) (default)
+   * - [JSONPointer](https://tools.ietf.org/html/rfc6901)
    */
-  public select(
+  public query(
     node: schema.Node,
-    pointer: string | number | (string | number)[]
+    query: string,
+    lang: 'jmes-path' | 'json-pointer' = 'jmes-path'
   ): Promise<schema.Node> {
-    return this.call<schema.Node>(Method.select, { node, pointer })
+    return this.call<schema.Node>(Method.query, { node, query, lang })
   }
 
   /**
@@ -315,10 +316,10 @@ export abstract class Executor {
         return this.manifest()
       case Method.decode:
         return this.decode(param(0, 'content'), param(1, 'format'))
-      case Method.select:
-        return this.select(param(0, 'node'), param(1, 'pointer'))
       case Method.encode:
         return this.encode(param(0, 'node'), param(1, 'format'))
+      case Method.query:
+        return this.query(param(0, 'node'), param(1, 'query'), param(1, 'lang', false))
       case Method.compile:
         return this.compile(param(0, 'node'))
       case Method.build:

--- a/src/http/HttpServer.ts
+++ b/src/http/HttpServer.ts
@@ -140,7 +140,7 @@ export class HttpServer extends TcpServer {
     app.post('/manifest', wrap('manifest'))
     app.post('/decode', wrap('decode'))
     app.post('/encode', wrap('encode'))
-    app.post('/select', wrap('select'))
+    app.post('/query', wrap('query'))
     app.post('/compile', wrap('compile'))
     app.post('/build', wrap('build'))
     app.post('/execute', wrap('execute'))

--- a/src/test/testClient.ts
+++ b/src/test/testClient.ts
@@ -28,7 +28,7 @@ export const testClient = async (client: Client): Promise<void> => {
    */
   expect(await client.decode('3.14', 'json')).toEqual(3.14)
   expect(await client.encode(3.14, 'json')).toEqual('3.14')
-  expect(await client.select({ a: 1 }, 'a')).toEqual(1)
+  expect(await client.query({ a: 1 }, 'a')).toEqual(1)
   expect(await client.execute(expr)).toEqual({ ...expr, output: 42 })
 
   /**
@@ -38,7 +38,7 @@ export const testClient = async (client: Client): Promise<void> => {
     await client.pipe(JSON.stringify(expr), [
       [Method.decode, { format: 'json' }],
       Method.execute,
-      [Method.select, { pointer: 'output' }],
+      [Method.query, { query: 'output' }],
       [Method.encode, { format: 'json' }]
     ])
   ).toBe('42')


### PR DESCRIPTION
Replaces the `select` method with `query` (instead of expanding API surface) to provide for other query languages. Adds JMESPath as the default query language.
