### PR TITLE
Websocket stalling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7735,46 +7735,6 @@
         "send": "^0.16.0"
       }
     },
-    "fastify-websocket": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastify-websocket/-/fastify-websocket-1.1.2.tgz",
-      "integrity": "sha512-2PYJ2HsUQ0sQz0e6nj3fswmPeVUZPLCjL0DHkh9q3rRANrm7edr9SUOQDxYGvg5vbz32jLPzVNyA4WOl1GoZMQ==",
-      "requires": {
-        "fastify-plugin": "^1.6.1",
-        "find-my-way": "^2.2.2",
-        "ws": "^7.2.3"
-      },
-      "dependencies": {
-        "fastify-plugin": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.1.tgz",
-          "integrity": "sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==",
-          "requires": {
-            "semver": "^6.3.0"
-          }
-        },
-        "find-my-way": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.2.tgz",
-          "integrity": "sha512-zk3eOsS1tABNQjII0vCbhkqgsX/COpRUxl0b5rlA41V2Ft7jWDr30LhYq4BZXLAlzw5yskg24XQG/U1wCT30vQ==",
-          "requires": {
-            "fast-decode-uri-component": "^1.0.0",
-            "safe-regex2": "^2.0.0",
-            "semver-store": "^0.3.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "ws": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
-        }
-      }
-    },
     "fastparallel": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "fastify-cors": "^3.0.3",
     "fastify-jwt": "^1.3.1",
     "fastify-static": "^2.7.0",
-    "fastify-websocket": "^1.1.2",
     "globby": "^11.0.0",
     "historic-readline": "^1.0.8",
     "isomorphic-ws": "^4.0.1",

--- a/src/tcp/TcpServer.ts
+++ b/src/tcp/TcpServer.ts
@@ -1,20 +1,19 @@
 import { getLogger } from '@stencila/logga'
+import * as schema from '@stencila/schema'
 import crypto from 'crypto'
 import net from 'net'
-import { Executor, Claims } from '../base/Executor'
+import { Connection } from '../base/Connection'
+import { Executor } from '../base/Executor'
+import { Server } from '../base/Server'
 import {
+  Addresses,
+  HttpAddress,
   TcpAddress,
   TcpAddressInitializer,
-  HttpAddress,
-  Addresses,
   Transport,
   WebSocketAddress,
 } from '../base/Transports'
 import { StreamServer } from '../stream/StreamServer'
-import { Server } from '../base/Server'
-import { Connection } from '../base/Connection'
-import * as schema from '@stencila/schema'
-import { thisExpression } from '@babel/types'
 import { expandAddress } from './util'
 
 const log = getLogger('executa:tcp:server')

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -197,24 +197,30 @@ test('WebSocketClient and WebSocketServer', async () => {
   await server.stop()
 })
 
-jest.setTimeout(5 * 60 * 1000)
+test('Many messages of increasing sizes', async () => {
+  // A regression test for https://github.com/stencila/executa/issues/141/
+  jest.setTimeout(60 * 1000)
 
-test.only('Large Websocket message sizes', async () => {
   const server = new WebSocketServer()
   const client = new WebSocketClient(server.address)
 
   const executor = new Worker()
   await server.start(executor)
 
-  for (let exponent = 1; exponent < 20; exponent++) {
-    for (let replicate = 0; replicate < 10; replicate++) {
+  const maxExponent = 25
+  const maxReplicate = 10
+  let exponent
+  let replicate
+  for (exponent = 1; exponent < maxExponent; exponent++) {
+    for (replicate = 0; replicate < maxReplicate; replicate++) {
       const size = Math.pow(2, exponent)
-      console.log(exponent, size, replicate)
       const sent = `${exponent},${replicate}:` + '-'.repeat(size)
       const received = await client.decode(`"${sent}"`, 'json')
       expect(received).toBe(sent)
     }
   }
+  expect(exponent).toBe(maxExponent)
+  expect(replicate).toBe(maxReplicate)
 
   await client.stop()
   await server.stop()

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -196,3 +196,26 @@ test('WebSocketClient and WebSocketServer', async () => {
 
   await server.stop()
 })
+
+jest.setTimeout(5 * 60 * 1000)
+
+test.only('Large Websocket message sizes', async () => {
+  const server = new WebSocketServer()
+  const client = new WebSocketClient(server.address)
+
+  const executor = new Worker()
+  await server.start(executor)
+
+  for (let exponent = 1; exponent < 20; exponent++) {
+    for (let replicate = 0; replicate < 10; replicate++) {
+      const size = Math.pow(2, exponent)
+      console.log(exponent, size, replicate)
+      const sent = `${exponent},${replicate}:` + '-'.repeat(size)
+      const received = await client.decode(`"${sent}"`, 'json')
+      expect(received).toBe(sent)
+    }
+  }
+
+  await client.stop()
+  await server.stop()
+})

--- a/src/ws/WebSocketServer.ts
+++ b/src/ws/WebSocketServer.ts
@@ -1,21 +1,20 @@
 import { getLogger } from '@stencila/logga'
 import * as schema from '@stencila/schema'
-// @ts-ignore
-import fastifyWebsocket from 'fastify-websocket'
+import crypto from 'crypto'
 import WebSocket from 'isomorphic-ws'
+import jsonwebtoken from 'jsonwebtoken'
 import { Connection } from '../base/Connection'
+import { Claims, Executor } from '../base/Executor'
 import { JsonRpcRequest } from '../base/JsonRpcRequest'
 import {
-  WebSocketAddress,
-  WebSocketAddressInitializer,
-  Transport,
   Addresses,
+  Transport,
+  WebSocketAddress,
+  WebSocketAddressInitializer
 } from '../base/Transports'
-import { HttpServer } from '../http/HttpServer'
-import { send, isOpen, parseProtocol } from './util'
-import { Claims } from '../base/Executor'
-import { FastifyInstance } from 'fastify'
+import { TcpServer } from '../tcp/TcpServer'
 import { expandAddress } from '../tcp/util'
+import { isOpen, parseProtocol, send } from './util'
 
 const log = getLogger('executa:ws:server')
 
@@ -93,16 +92,36 @@ export class WebSocketConnection implements Connection {
 /**
  * A `Server` using WebSockets as the transport protocol.
  */
-export class WebSocketServer extends HttpServer {
+export class WebSocketServer extends TcpServer {
+  /**
+   * The WebSocket server.
+   */
+  wsServer?: WebSocket.Server
+
+  /**
+   * The secret used to verify JWT tokens.
+   *
+   * If this is not provided to the constructor
+   * then a random secret will be generated and
+   * logged for use in generating tokens.
+   */
+  public readonly jwtSecret: string
+
   public constructor(
     address: WebSocketAddressInitializer = new WebSocketAddress({ port: 9000 }),
     jwtSecret?: string
   ) {
-    super(address, jwtSecret)
+    super(address)
+
+    if (jwtSecret === undefined) {
+      jwtSecret = crypto.randomBytes(16).toString('hex')
+      log.info(`JWT secret generated for Websocket server: ${jwtSecret}`)
+    }
+    this.jwtSecret = jwtSecret
   }
 
   /**
-   * @override Overrides {@link HttpServer.addresses}
+   * @override Overrides {@link TcpServer.addresses}
    * to provide a WebSocket entry.
    */
   public async addresses(): Promise<Addresses> {
@@ -112,58 +131,79 @@ export class WebSocketServer extends HttpServer {
   }
 
   /**
-   * @override Overrides {@link HttpServer.buildApp} to add WebSocket
-   * handling.
+   * @override Overrides {@link TcpServer.start} to start
+   * a WebSocket server.
    */
-  protected buildApp(): FastifyInstance {
-    const app = super.buildApp()
-    app.register(fastifyWebsocket, {
-      handle: (connection: fastifyWebsocket.SocketStream) => {
-        const { socket } = connection
+  public start(executor: Executor): Promise<void> {
+    this.executor = executor
 
-        // Extract id and jwt from the protocol ('sec-websocket-protocol' header)
-        // and verify the user jwt
-        let id = ''
-        let jwt
+    log.debug(`Starting Websocket server: ${this.address.url()}`)
+
+    const [host, port] = this.listeningAddress()
+    this.wsServer = new WebSocket.Server({ port, host })
+
+    this.wsServer.on('connection', (socket: WebSocket) => {
+      // Extract id and jwt from the protocol ('sec-websocket-protocol' header)
+      // and verify the user jwt
+      let id = ''
+      let jwt
+      if (socket.protocol !== undefined && socket.protocol.length > 0) {
         try {
           ;({ id, jwt } = parseProtocol(socket.protocol))
         } catch (error) {
           log.warn(error)
         }
-        let claims: Claims = {}
-        if (jwt !== undefined) {
-          try {
-            claims = app.jwt.verify(jwt)
-          } catch (error) {
-            // If verification failed then close the connection
-            // with a 4001 code (mirrors the HTTP 401 code used by `HttpServer`
-            // in the same circumstance but in range assigned for application use
-            // by the WebSockets API)
-            socket.close(4001, error.message)
-            return
-          }
+      }
+
+      let claims: Claims = {}
+      if (jwt !== undefined) {
+        try {
+          claims = jsonwebtoken.verify(jwt, this.jwtSecret) as object
+        } catch (error) {
+          // If verification failed then close the connection
+          // with a 4001 code (mirrors the HTTP 401 code used by `HttpServer`
+          // in the same circumstance but in range assigned for application use
+          // by the WebSockets API)
+          socket.close(4001, error.message)
+          return
         }
+      }
 
-        // Register connection and disconnection handler
-        const wsconnection = new WebSocketConnection(socket, id, claims)
-        this.onConnected(wsconnection)
-        socket.on('close', () => this.onDisconnected(wsconnection))
+      // Register connection and disconnection handler
+      const wsconnection = new WebSocketConnection(socket, id, claims)
+      this.onConnected(wsconnection)
+      socket.on('close', () => this.onDisconnected(wsconnection))
 
-        // Handle messages from connection
-        const onMessage = async (message: string): Promise<void> => {
-          const response = await this.receive(message, wsconnection.claims)
-          if (response !== undefined)
-            await wsconnection.send(response as string)
-        }
-        socket.on('message', (message: string) => {
-          onMessage(message).catch((error: Error) => log.error(error))
-        })
+      // Handle messages from connection
+      const onMessage = async (message: string): Promise<void> => {
+        const response = await this.receive(message, wsconnection.claims)
+        if (response !== undefined) await wsconnection.send(response as string)
+      }
+      socket.on('message', (message: string) => {
+        onMessage(message).catch((error: Error) => log.error(error))
+      })
 
-        // Handle any errors
-        socket.on('error', (error: Error) => log.error(error))
-      },
-      options: {},
+      // Handle any errors
+      socket.on('error', (error: Error) => log.error(error))
     })
-    return app
+
+    return Promise.resolve()
+  }
+
+  /**
+   * @override Overrides {@link TcpServer.stop} to stop the
+   * WebSocket server.
+   *
+   * Calls `super.stop()` to close all connections.
+   */
+  public async stop(): Promise<void> {
+    await super.stop()
+
+    if (this.wsServer !== undefined) {
+      log.debug(`Stopping WebSocket server: ${this.address.url()}`)
+      this.wsServer.close()
+    }
+
+    return Promise.resolve()
   }
 }

--- a/src/ws/serverLoad.e2e.ts
+++ b/src/ws/serverLoad.e2e.ts
@@ -1,0 +1,173 @@
+/**
+ * A script for testing sending several messages of increasing sizes to
+ * various WebSocket server implementations with different client creation
+ * strategies (one, each with many requests vs many, each with one request).
+ *
+ * Run like this (one process for server, one for client/s):
+ *
+ * ```sh
+ * npx ts-node --project tsconfig.cli.json  --files src/ws/serverLoad.e2e.ts server-ws
+ * ```
+ *
+ * Written to try to resolve issue https://github.com/stencila/executa/issues/141.
+ * These results, showing the highest exponent / repetition befor hanging
+ * suggest that problem resides in the fastify server:
+ *
+ * Combo                                Exponent   Replicate
+ *
+ * `server-executa` + `client-one`:        9        6
+ * `server-executa` + `client-many`:      19        9
+ *
+ * `server-fastify` + `client-one`:        9        6
+ * `server-fastify` + `client-many`:      19        9
+ *
+ * `server-ws` + `client-one`:            19        9
+ * `server-ws` + `client-many`:           19        9
+ */
+
+
+import fastify from 'fastify'
+import fastifyWebsocket from 'fastify-websocket'
+import WebSocket from 'ws'
+import { JsonRpcRequest } from '../base/JsonRpcRequest'
+import { Worker } from '../base/Worker'
+import { WebSocketServer } from './WebSocketServer'
+
+const mode = process.argv[2]
+
+if (mode === 'server-executa') {
+  /**
+   * Run Executa's `WebSocketServer`
+   */
+  const server = new WebSocketServer()
+  const executor = new Worker()
+  server.start(executor)
+} else if (mode === 'server-fastify') {
+  /**
+   * Run `fastify` server with the `fastify-websocket`
+   * plugin. This is what Executa's `WebSocketServer`
+   * is currently built on.
+   */
+  const server = fastify()
+  server.register(fastifyWebsocket, {
+    handle: (connection: any) => {
+      const { socket } = connection
+      socket.on('message', (message: string) => {
+        console.log('recv', message.substring(0, 60))
+        socket.send(message, (error: any) => {
+          if (error !== undefined) {
+            console.error(error)
+            process.exit(1)
+          }
+          console.log('sent', message.substring(0, 60))
+        })
+      })
+    }
+  })
+  server.listen(9000)
+} else if (mode === 'server-ws') {
+  /**
+   * Run a `ws` server.  This is what `fastify-websocket`
+   * is built on.
+   */
+  const server = new WebSocket.Server({
+    port: 9000
+  })
+  server.on('connection', socket => {
+    socket.on('message', message => {
+      console.log('recv', message.toString().substring(0, 60))
+      socket.send(message, error => {
+        if (error !== undefined) {
+          console.error(error)
+          process.exit(1)
+        }
+        console.log('sent', message.toString().substring(0, 60))
+      })
+    })
+  })
+} else if (mode === 'client-one') {
+  /**
+   * Create one plain `WebSocket` client and
+   * make multiple requests of increasing payload size
+   */
+  let exponent = 1
+  let replicate = 0
+  function send() {
+    if (exponent > 19) process.exit(0)
+    else if (replicate >= 9) {
+      exponent += 1
+      replicate = 1
+    } else replicate += 1
+
+    const size = Math.pow(2, exponent)
+    const payload = JSON.stringify(
+      `${exponent}:${replicate}:` + '-'.repeat(size)
+    )
+    const request = new JsonRpcRequest('decode', {
+      source: payload,
+      format: 'json'
+    })
+    const message = JSON.stringify(request)
+    client.send(message, error => {
+      if (error !== undefined) {
+        console.error(error)
+        process.exit(1)
+      }
+      console.log('sent', exponent, replicate, message.substring(0, 60))
+    })
+  }
+  const client = new WebSocket('ws://127.0.0.1:9000')
+  client
+    .on('open', () => {
+      send()
+    })
+    .on('error', err => {
+      console.error(`Connection error: ${err}`)
+      process.exit(1)
+    })
+    .on('close', () => {
+      console.log('Connection closed')
+      process.exit(0)
+    })
+    .on('message', (message: string) => {
+      console.log('recv', exponent, replicate, message.substring(0, 60))
+      send()
+    })
+} else if (mode === 'client-many') {
+  /**
+   * Create many `WebSocket` clients, one for each of
+   * multiple requests of increasing payload size.
+   */
+  for (let exponent = 1; exponent < 20; exponent++) {
+    for (let replicate = 0; replicate < 10; replicate++) {
+      const client = new WebSocket('ws://127.0.0.1:9000')
+      client
+        .on('open', () => {
+          const size = Math.pow(2, exponent)
+          const payload = JSON.stringify(
+            `${exponent}:${replicate}:` + '-'.repeat(size)
+          )
+          const request = new JsonRpcRequest('decode', {
+            source: payload,
+            format: 'json'
+          })
+          const message = JSON.stringify(request)
+          client.send(message, error => {
+            if (error !== undefined) console.error(error)
+            console.log('sent', exponent, replicate, message.substring(0, 60))
+          })
+        })
+        .on('error', err => {
+          console.error(`Connection error: ${err}`)
+          process.exit(1)
+        })
+        .on('close', () => {
+          console.log('Connection closed')
+          process.exit(0)
+        })
+        .on('message', (message: string) => {
+          console.log('recv', exponent, replicate, message.substring(0, 60))
+        })
+    }
+  }
+}


### PR DESCRIPTION
Attempts to address #141 

Have added a test  and have been using debugger to investigate. Findings so far:

- setting the `maxPayload` option on either / both the server or client does not fix the issue (however, it should not be discounted as part of a potential solution once we find the cause)

- the issue is not about individual message size alone, but seemingly has something to do with an accumulated message size:
    - with the current test settings, the connection stalls when it get's to the 3rd repetition of a 512 byte message
   - but if you start with `exponent=10` it gets to the 3rd iteration of the 2048 byte messages