### PR TITLE
Fix WebSocket retry logic

### DIFF
--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -94,6 +94,10 @@ export class WebSocketClient extends Client {
       return Promise.resolve()
     }
 
+    if (this.options.logging) {
+      log.info(`Connection closed, trying to reconnect`)
+    }
+
     this.isRetrying = true
     return retry(() => this.start(), {
       retries: this.options.retries,

--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -64,7 +64,7 @@ export class WebSocketClient extends Client {
    *
    * Used to determine whether to try to reconnect.
    */
-  private stopped = false
+  private isStopped = false
 
   /**
    * Is this client attempting to reestablish a connection
@@ -139,7 +139,7 @@ export class WebSocketClient extends Client {
       )
 
       this.socket.onopen = () => {
-        this.stopped = false
+        this.isStopped = false
         resolve()
       }
 
@@ -149,7 +149,7 @@ export class WebSocketClient extends Client {
       this.socket.onclose = (event: CloseEvent) => {
         // Try to reconnect if not explicitly closed or if
         // authentication failed
-        if (this.stopped === true) return resolve()
+        if (this.isStopped) return resolve()
 
         const { code, reason } = event
         if (code === 4001) {
@@ -223,7 +223,7 @@ export class WebSocketClient extends Client {
    * Stop the connection by closing the WebSocket.
    */
   public stop(): Promise<void> {
-    this.stopped = true
+    this.isStopped = true
     if (this.socket !== undefined) this.socket.close()
     return Promise.resolve()
   }

--- a/src/ws/WebSocketClient.ts
+++ b/src/ws/WebSocketClient.ts
@@ -67,6 +67,11 @@ export class WebSocketClient extends Client {
   private stopped = false
 
   /**
+   * Is this client attempting to reestablish a connection
+   */
+  public isRetrying: boolean | undefined
+
+  /**
    * Construct a `WebSocketClient`.
    *
    * @param address The address of the server to connect to
@@ -78,6 +83,41 @@ export class WebSocketClient extends Client {
     super('ws')
     this.address = new WebSocketAddress(address)
     this.options = { ...defaultWebSocketClientOptions, ...options }
+  }
+
+  private retryConnect = (
+    resolve: (a: void | PromiseLike<void>) => void,
+    reject: (a: Error) => void
+  ): Promise<void> => {
+    // Terminate early if already attempting to reconnect
+    if (this.isRetrying === true) {
+      return Promise.resolve()
+    }
+
+    this.isRetrying = true
+    return retry(() => this.start(), {
+      retries: this.options.retries,
+      randomize: true,
+      maxTimeout: 5000,
+      onFailedAttempt: (error) => {
+        if (this.options.logging) {
+          log.info(
+            `Connection attempt ${error.attemptNumber} failed. ${error.retriesLeft} retries left.`
+          )
+        }
+      },
+    })
+      .then(resolve)
+      .catch(() => {
+        reject(
+          new Error(
+            `Failed to reconnect after ${this.options.retries} attempt(s)`
+          )
+        )
+      })
+      .finally(() => {
+        this.isRetrying = false
+      })
   }
 
   /**
@@ -92,34 +132,57 @@ export class WebSocketClient extends Client {
       address,
       options: { retries, logging },
     } = this
-    const socket = (this.socket = new WebSocket(
-      address.url(),
-      generateProtocol(id, address.jwt)
-    ))
-    socket.onmessage = (event: MessageEvent) =>
-      this.receive(event.data.toString())
-    socket.onclose = (event: CloseEvent) => {
-      // Try to reconnect if not explicitly closed or if
-      // authentication failed
-      if (this.stopped === true) return
-      const { code, reason } = event
-      if (code === 4001) {
-        if (logging) log.error(`Failed to authenticate with server: ${reason}`)
-        return
+    return new Promise((resolve, reject) => {
+      this.socket = new WebSocket(
+        address.url(),
+        generateProtocol(id, address.jwt)
+      )
+
+      this.socket.onopen = () => {
+        this.stopped = false
+        resolve()
       }
-      if (retries > 0) {
-        if (logging) log.info(`Connection closed, trying to reconnect`)
-        retry(() => this.start(), {
-          retries,
-          randomize: true,
-        }).catch((error) => log.error(error))
+
+      this.socket.onmessage = (event: MessageEvent) =>
+        this.receive(event.data.toString())
+
+      this.socket.onclose = (event: CloseEvent) => {
+        // Try to reconnect if not explicitly closed or if
+        // authentication failed
+        if (this.stopped === true) return resolve()
+
+        const { code, reason } = event
+        if (code === 4001) {
+          const error = `Failed to authenticate with server: ${reason}`
+          if (logging) {
+            log.error(error)
+          }
+
+          reject(new Error(error))
+        }
+
+        if (retries > 0 && this.isRetrying === undefined) {
+          // Configured to reconnect, but the process hasn't been started yet
+          return this.retryConnect(resolve, reject)
+        } else if (this.isRetrying === true) {
+          // Configured to reconnect, and the process is already in progress
+          return undefined
+        } else {
+          // Not configured to reconnect, or the reconnect process failed
+          reject(new Error('Connection closed.'))
+        }
       }
-    }
-    socket.onerror = (error: ErrorEvent) => {
-      if (logging) log.error(error.message)
-    }
-    this.stopped = false
-    return Promise.resolve()
+
+      this.socket.onerror = (error: ErrorEvent) => {
+        if (logging) log.error(error.message)
+
+        if (retries > 0 && this.isRetrying === undefined) {
+          return this.retryConnect(resolve, reject)
+        } else {
+          reject(new Error(error.message))
+        }
+      }
+    })
   }
 
   /**

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -14,40 +14,47 @@ import { Worker } from '../base/Worker'
 // unnecessary failures.
 const delayMilliseconds = process.env.CI !== undefined ? 100 : 25
 
-test('WebSocketClient and WebSocketServer', async () => {
-  let serverLogs: LogData[] = []
+let server: WebSocketServer
+let serverLogs: LogData[] = []
+let clientLogs: LogData[] = []
+
+// @ts-ignore that connections is private
+const serverConnections = () => Object.values(server.connections).length
+
+beforeEach(() => {
+  server = new WebSocketServer()
+  const executor = new EchoExecutor()
+
+  serverLogs = []
   addHandler((logData: LogData) => {
     if (logData.tag === 'executa:ws:server') {
       serverLogs = [...serverLogs, logData]
     }
   })
 
-  let clientLogs: LogData[] = []
+  clientLogs = []
   addHandler((logData: LogData) => {
     if (logData.tag === 'executa:ws:client') {
       clientLogs = [...clientLogs, logData]
     }
   })
 
-  const server = new WebSocketServer()
-  const executor = new EchoExecutor()
-  await server.start(executor)
+  return server.start(executor)
+})
 
-  // @ts-ignore that connections is private
-  const serverConnections = () => Object.values(server.connections).length
+afterEach(() => server.stop())
 
-  {
-    // Well behaved client
+describe('WebSocketClient and WebSocketServer', () => {
+  test('Well behaved client', async () => {
     const client = new WebSocketClient(server.address)
     await testClient(client)
     await client.stop()
-  }
 
-  await delay(delayMilliseconds)
-  expect(serverConnections()).toBe(0)
+    await delay(delayMilliseconds)
+    expect(serverConnections()).toBe(0)
+  })
 
-  {
-    // JWT with session limits to be used for begin() method
+  test('JWT with session limits to be used for begin() method', async () => {
     const sessionRequests = schema.softwareSession({
       environment: schema.softwareEnvironment({ name: 'some-environment' }),
       cpuRequest: 4,
@@ -71,26 +78,23 @@ test('WebSocketClient and WebSocketServer', async () => {
     expect(userClient).toHaveProperty('id')
 
     await client.stop()
-  }
 
-  await delay(delayMilliseconds)
-  expect(serverConnections()).toBe(0)
+    await delay(delayMilliseconds)
+    expect(serverConnections()).toBe(0)
+  })
 
-  {
-    // Client with malformed JWT
-    clientLogs = []
+  test('Client with malformed JWT', async () => {
     const client = new WebSocketClient({ ...server.address, jwt: 'what?' })
     await client.start()
     await delay(delayMilliseconds)
+
     expect(serverConnections()).toBe(0)
-    expect(clientLogs.length).toBe(1)
+    expect(clientLogs.length).toBeGreaterThanOrEqual(1)
     expect(clientLogs[0].message).toMatch(/Failed to authenticate with server/)
     await client.stop()
-  }
+  })
 
-  {
-    // Client with invalid JWT
-    clientLogs = []
+  test('Client with invalid JWT', async () => {
     const client = new WebSocketClient({
       ...server.address,
       jwt: JWT.sign({}, 'not-the-right-secret'),
@@ -98,13 +102,12 @@ test('WebSocketClient and WebSocketServer', async () => {
     await client.start()
     await delay(delayMilliseconds)
     expect(serverConnections()).toBe(0)
-    expect(clientLogs.length).toBe(1)
+    expect(clientLogs.length).toBeGreaterThanOrEqual(1)
     expect(clientLogs[0].message).toMatch(/Failed to authenticate with server/)
     await client.stop()
-  }
+  })
 
-  {
-    // Clients reconnect after disconnection
+  test('Clients reconnect after disconnection', async () => {
     const client1 = new WebSocketClient(server.address)
     const client2 = new WebSocketClient(server.address)
     const client3 = new WebSocketClient(server.address)
@@ -116,8 +119,6 @@ test('WebSocketClient and WebSocketServer', async () => {
     await client3.start()
     await delay(delayMilliseconds)
     expect(serverConnections()).toBe(3)
-
-    clientLogs = []
 
     await server.stop()
     expect(serverConnections()).toBe(0)
@@ -137,10 +138,9 @@ test('WebSocketClient and WebSocketServer', async () => {
 
     await delay(delayMilliseconds)
     expect(serverConnections()).toBe(0)
-  }
+  })
 
-  {
-    // Sending notifications to several clients
+  test('Sending notifications to several clients', async () => {
     const client1 = new WebSocketClient(server.address)
     const client2 = new WebSocketClient(server.address)
     const client3 = new WebSocketClient(server.address)
@@ -197,20 +197,14 @@ test('WebSocketClient and WebSocketServer', async () => {
     expect(client1.notifications.length).toBe(2)
     expect(client2.notifications.length).toBe(2)
     expect(client3.notifications.length).toBe(2)
-  }
-
-  await server.stop()
+  })
 })
 
 test('Many messages of increasing sizes', async () => {
   // A regression test for https://github.com/stencila/executa/issues/141/
   jest.setTimeout(60 * 1000)
 
-  const server = new WebSocketServer()
   const client = new WebSocketClient(server.address)
-
-  const executor = new Worker()
-  await server.start(executor)
 
   const maxExponent = 25
   const maxReplicate = 10
@@ -228,5 +222,4 @@ test('Many messages of increasing sizes', async () => {
   expect(replicate).toBe(maxReplicate)
 
   await client.stop()
-  await server.stop()
 })

--- a/src/ws/WebSocketClientServer.test.ts
+++ b/src/ws/WebSocketClientServer.test.ts
@@ -67,6 +67,7 @@ describe('WebSocketClient and WebSocketServer', () => {
         memoryLimit: 2,
       }),
     }
+
     // Sign with the server's secret
     const jwt = JWT.sign(claims, server.jwtSecret)
     const client = new WebSocketClient({ ...server.address, jwt })
@@ -127,7 +128,7 @@ describe('WebSocketClient and WebSocketServer', () => {
     await delay(delayMilliseconds)
 
     expect(serverConnections()).toBe(3)
-    expect(clientLogs.length).toBe(3)
+    expect(clientLogs.length).toBeGreaterThanOrEqual(3)
     expect(clientLogs[0].message).toMatch(
       /Connection closed, trying to reconnect/
     )


### PR DESCRIPTION
This PR refactors the WebSocket client to avoid an infinite recursion when a connection fails.
It does so by returning a promise from the `start` method.